### PR TITLE
Correction of chromatin_trace_table class name

### DIFF
--- a/src/postProcessing/trace_combinator.py
+++ b/src/postProcessing/trace_combinator.py
@@ -13,7 +13,7 @@ $ trace_combinator.py
 
 outputs
 
-chromatin_trace_table() object and output .ecsv formatted file with assembled trace tables.
+ChromatinTraceTable() object and output .ecsv formatted file with assembled trace tables.
 
 
 """
@@ -30,7 +30,7 @@ import argparse
 import csv
 import glob
 
-from matrixOperations.chromatin_trace_table import chromatin_trace_table
+from matrixOperations.chromatin_trace_table import ChromatinTraceTable
 
 # =============================================================================
 # FUNCTIONS
@@ -91,10 +91,10 @@ def parseArguments():
 
 def load_traces(folders, ndims = 3, method = 'mask'):
 
-    traces = chromatin_trace_table()
+    traces = ChromatinTraceTable()
     traces.initialize()
     traces.number_traces = 0
-    new_trace = chromatin_trace_table()
+    new_trace = ChromatinTraceTable()
 
     for folder in folders:
         trace_files = [x for x in glob.glob(folder.rstrip('/') + os.sep + 'Trace*ecsv') if 'uniqueBarcodes' not in x]

--- a/src/postProcessing/trace_selector.py
+++ b/src/postProcessing/trace_selector.py
@@ -11,7 +11,7 @@ $ trace_selector.py
 
 outputs
 
-chromatin_trace_table() object and output .ecsv trace table file .
+ChromatinTraceTable() object and output .ecsv trace table file .
 
 
 """
@@ -28,7 +28,7 @@ import argparse
 import csv
 import glob
 
-from matrixOperations.chromatin_trace_table import chromatin_trace_table
+from matrixOperations.chromatin_trace_table import ChromatinTraceTable
 from imageProcessing.imageProcessing import Image
 
 # =============================================================================
@@ -99,7 +99,7 @@ def process_traces(folder, pixel_size = 0.1):
         # iterates over traces in folder
         for trace_file in trace_files:
 
-            trace = chromatin_trace_table()
+            trace = ChromatinTraceTable()
             trace.initialize()
 
             #reads new trace


### PR DESCRIPTION
Convert "chromatin_trace_table" class name into "ChromatinTraceTable", forgotten in commit 5b7382d.