### PR TITLE
Fix issue/109

### DIFF
--- a/src/matrixOperations/filter_localizations.py
+++ b/src/matrixOperations/filter_localizations.py
@@ -9,7 +9,7 @@ Created on Mon Feb  7 16:45:44 2022
 # IMPORTS
 # =============================================================================
 
-import glob
+import glob, os
 
 # to remove in a future version
 import warnings
@@ -226,7 +226,7 @@ class FilterLocalizations:
 
                 for file in files:
 
-                    if "3D" in file:
+                    if "3D" in os.path.basename(file):
                         self.ndims = 3
                     else:
                         self.ndims = 2

--- a/src/matrixOperations/register_localizations.py
+++ b/src/matrixOperations/register_localizations.py
@@ -336,7 +336,7 @@ class RegisterLocalizations:
 
     def register_barcode_map_file(self, file):
 
-        if "3D" in file:
+        if "3D" in os.path.basename(file):
             self.ndims = 3
         else:
             self.ndims = 2


### PR DESCRIPTION
Changes in this PR:
- added os.path.basename to command parsing filenames to avoid conflict when folder contains the string '3D'
- replaced a `return` by a `sys.exit` in `register_localizations` module as otherwise risk that corrections are not applied and user does not realize