### PR TITLE
Add option to process single file in localize_3d

### DIFF
--- a/src/core/function_caller.py
+++ b/src/core/function_caller.py
@@ -47,7 +47,7 @@ from matrixOperations.register_localizations import (
 class Pipeline:
     """Class for high level function calling"""
 
-    def __init__(self, data_m, cmd_list, is_parallel, logger):
+    def __init__(self, data_m, cmd_list, is_parallel, logger, input_file=None):
         self.m_data_m = data_m
         self.cmds = self.interpret_cmd_list(cmd_list)
         self.set_params_from_cmds()
@@ -55,6 +55,7 @@ class Pipeline:
         self.m_logger = logger
         self.m_dask = None
         self.features = []
+        self.input_file = input_file
         self.init_features()
 
     def interpret_cmd_list(self, cmd_list):
@@ -430,7 +431,10 @@ class Pipeline:
                 parallel=self.parallel,
             )
             _segment_sources_3d.segment_sources_3d(
-                data_path, dict_shifts_path, segmentation_params
+                data_path,
+                dict_shifts_path,
+                segmentation_params,
+                single_file_to_process=self.input_file,
             )
 
     def run(self):  # sourcery skip: remove-pass-body

--- a/src/core/run_args.py
+++ b/src/core/run_args.py
@@ -55,6 +55,16 @@ def _parse_run_args(command_line_arguments):
         help="Thread number to run with parallel mode.\nDEFAULT: 1 (sequential mode)",
     )
 
+    parser.add_argument(
+        "-I",
+        "--inputFile",
+        type=str,
+        default=None,
+        help="Optional name of a single image file to process. When provided,\n"
+        "        pyHiM will restrict processing to this file (when compatible\n"
+        "        with the selected command).",
+    )
+
     return parser.parse_args(command_line_arguments)
 
 
@@ -72,6 +82,7 @@ class RunArgs:
         self.thread_nbr = parsed_args.threads
         self.parallel = self.thread_nbr > 1
         self.params_path = parsed_args.parameters
+        self.input_file = parsed_args.inputFile
         self._check_consistency()
 
     def _is_docker(self):
@@ -124,6 +135,8 @@ class RunArgs:
         to_print += tab_spacer("threads", str(self.thread_nbr))
         to_print += tab_spacer("parallel", str(self.parallel))
         to_print += tab_spacer("cmd", str(self.cmd_list))
+        if self.input_file:
+            to_print += tab_spacer("inputFile", str(self.input_file))
 
         return to_print
 

--- a/src/core/run_args.py
+++ b/src/core/run_args.py
@@ -60,9 +60,11 @@ def _parse_run_args(command_line_arguments):
         "--inputFile",
         type=str,
         default=None,
-        help="Optional name of a single image file to process. When provided,\n"
-        "        pyHiM will restrict processing to this file (when compatible\n"
-        "        with the selected command).",
+        help=(
+            "Optional name of a single image file to process. When provided,\n"
+            "pyHiM will restrict processing to this file (when compatible\n"
+            "with the selected command)."
+        ),
     )
 
     return parser.parse_args(command_line_arguments)

--- a/src/imageProcessing/segmentSources3D.py
+++ b/src/imageProcessing/segmentSources3D.py
@@ -29,6 +29,7 @@ import glob
 import os
 import uuid
 from datetime import datetime
+from typing import Optional
 
 import numpy as np
 from apifish.identification.spot_modeling import fit_subpixel
@@ -83,6 +84,7 @@ class Localize3D:
         self.filenames_to_process_list = []
         self.inner_parallel_loop = None
         self.output_filename = None
+        self.single_file_to_process = None
 
         # parameters from parameters.json
         self.p["referenceBarcode"] = reg_params.referenceFiducial
@@ -434,6 +436,18 @@ class Localize3D:
             in self.current_param.decode_file_parts(os.path.basename(x))["cycle"]
         ]
 
+        if self.single_file_to_process:
+            self.filenames_to_process_list = [
+                x
+                for x in self.filenames_to_process_list
+                if os.path.basename(x) == self.single_file_to_process
+            ]
+            if not self.filenames_to_process_list:
+                raise SystemExit(
+                    f"Requested file '{self.single_file_to_process}' was not found"
+                    f" among the files to process in ROI [{self.roi}]."
+                )
+
         n_files_to_process = len(self.filenames_to_process_list)
         print_log(f"$ Found {n_files_to_process} files in ROI [{self.roi}]")
         print_log(
@@ -498,7 +512,11 @@ class Localize3D:
         )
 
     def segment_sources_3d(
-        self, data_path, dict_shifts_path, params: SegmentationParams
+        self,
+        data_path,
+        dict_shifts_path,
+        params: SegmentationParams,
+        single_file_to_process: Optional[str] = None,
     ):
         """
         runs 3D fitting routine in root_folder
@@ -520,6 +538,14 @@ class Localize3D:
         )
 
         # creates output folders and filenames
+        self.single_file_to_process = single_file_to_process
+        output_file_prefix = params.outputFile
+        if self.single_file_to_process:
+            base_name = os.path.splitext(
+                os.path.basename(self.single_file_to_process)
+            )[0]
+            output_file_prefix = f"{output_file_prefix}_{base_name}"
+
         self.output_filename = (
             data_path
             + os.sep
@@ -527,7 +553,7 @@ class Localize3D:
             + os.sep
             + "data"
             + os.sep
-            + params.outputFile
+            + output_file_prefix
             + "_3D_barcode.dat"
         )
 

--- a/src/pyHiM.py
+++ b/src/pyHiM.py
@@ -39,7 +39,9 @@ def main(command_line_arguments=None):
         param_file=run_args.params_path,
     )
 
-    pipe = fc.Pipeline(datam, run_args.cmd_list, run_args.parallel, logger)
+    pipe = fc.Pipeline(
+        datam, run_args.cmd_list, run_args.parallel, logger, run_args.input_file
+    )
     pipe.lauch_dask_scheduler(threads_requested=run_args.thread_nbr, maximum_load=0.8)
 
     pipe.run()


### PR DESCRIPTION
## Summary
- add a runtime argument to allow processing a single input file
- pass the selected file name into the localize_3d pipeline and restrict processing when provided
- name the generated localization table after the processed image when running a single-file job

## Testing
- python -m pytest tests/test_localize_3d.py -k reduce_planes_thresholding -q *(fails: ModuleNotFoundError: No module named 'core' during test import)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692dba943b54833092b8c40185325658)