### PR TITLE
Support single-file register_local runs

### DIFF
--- a/src/core/function_caller.py
+++ b/src/core/function_caller.py
@@ -299,6 +299,7 @@ class Pipeline:
         dict_shifts_path,
         roi_name,
         z_binning,
+        single_file_to_process=None,
     ):
         if label == "fiducial" and registration_params.localAlignment == "block3D":
             print_log(f"> Making 3D image registrations label: {label}")
@@ -306,7 +307,12 @@ class Pipeline:
                 current_param, registration_params, parallel=self.parallel
             )
             local_shifts_path = _drift_3d.align_fiducials_3d(
-                data_path, registration_params, dict_shifts_path, roi_name, z_binning
+                data_path,
+                registration_params,
+                dict_shifts_path,
+                roi_name,
+                z_binning,
+                single_file_to_process=single_file_to_process,
             )
             self.m_data_m.local_shifts_path = local_shifts_path
 

--- a/src/imageProcessing/alignImages3D.py
+++ b/src/imageProcessing/alignImages3D.py
@@ -177,6 +177,7 @@ class Drift3D:
         params: RegistrationParams,
         roi_name,
         z_binning,
+        single_file_to_process=None,
     ):
         """
         Refits all the barcode files found in root_folder
@@ -214,6 +215,16 @@ class Drift3D:
             for x in self.current_param.files_to_process
             if (x != self.filenames_with_ref_barcode)
         ]
+        if single_file_to_process:
+            self.filenames_to_process_list = [
+                x
+                for x in self.filenames_to_process_list
+                if os.path.basename(x) == os.path.basename(single_file_to_process)
+            ]
+            if not self.filenames_to_process_list:
+                raise SystemExit(
+                    f"Requested file '{single_file_to_process}' was not found among the files to process."
+                )
         number_files = len(self.filenames_to_process_list)
 
         if client is None:
@@ -259,12 +270,20 @@ class Drift3D:
 
             # del futures
 
-        # Merges Tables for different cycles and appends results Table to that of previous ROI
-        alignment_results_table_global = vstack(
-            [alignment_results_table_global] + alignment_results_tables
-        )
+        output_prefix = params.outputFile
+        if single_file_to_process:
+            output_prefix = (
+                output_prefix
+                + "_"
+                + os.path.splitext(os.path.basename(single_file_to_process))[0]
+            )
 
-        # saves Table with all shifts
+        if single_file_to_process and alignment_results_tables:
+            alignment_results_table_global = alignment_results_tables[0]
+        else:
+            alignment_results_table_global = vstack(
+                [alignment_results_table_global] + alignment_results_tables
+            )
 
         path_name = (
             data_path
@@ -273,7 +292,7 @@ class Drift3D:
             + os.sep
             + "data"
             + os.sep
-            + params.outputFile
+            + output_prefix
         )
         local_shifts_path = path_name + "_block3D.dat"
 
@@ -295,6 +314,7 @@ class Drift3D:
         dict_shifts_path,
         roi_name,
         z_binning,
+        single_file_to_process=None,
     ):
         """
         runs refitting routine in root_folder
@@ -313,7 +333,12 @@ class Drift3D:
         # self.current_log.parallel = self.parallel
 
         local_shifts_path = self.align_fiducials_3d_in_folder(
-            data_path, dict_shifts_path, params, roi_name, z_binning
+            data_path,
+            dict_shifts_path,
+            params,
+            roi_name,
+            z_binning,
+            single_file_to_process=single_file_to_process,
         )
 
         print_log(f"HiM matrix in {data_path} processed")

--- a/src/pyHiM.py
+++ b/src/pyHiM.py
@@ -86,6 +86,7 @@ def main(command_line_arguments=None):
                 datam.dict_shifts_path,
                 datam.processed_roi,
                 datam.acquisition_params.zBinning,
+                single_file_to_process=run_args.input_file,
             )
 
         # [segments DAPI and sources in 2D]


### PR DESCRIPTION
## Summary
- add optional single-file handling to register_local processing flow
- ensure register_local outputs include the processed filename when limiting to a single file
- thread input file argument through pipeline so only the requested fiducial stack is aligned

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692fdd4ba8d083308c21244b3404cbea)