### PR TITLE
Add single-file support to 3D mask segmentation

### DIFF
--- a/src/core/function_caller.py
+++ b/src/core/function_caller.py
@@ -359,6 +359,7 @@ class Pipeline:
         dict_shifts_path,
         acq_params: AcquisitionParams,
         reg_params: RegistrationParams,
+        single_file_to_process=None,
     ):
         if (label in ("DAPI", "mask")) and "3D" in current_param.param_dict[
             "segmentedObjects"
@@ -377,6 +378,7 @@ class Pipeline:
                 segmentation_params,
                 acq_params,
                 reg_params.referenceFiducial,
+                single_file_to_process=single_file_to_process,
             )
 
     def shift_mask(

--- a/src/imageProcessing/segmentMasks3D.py
+++ b/src/imageProcessing/segmentMasks3D.py
@@ -49,6 +49,7 @@ class Mask3D:
         self.dict_shifts_available = None
         self.filenames_to_process_list = []
         self.inner_parallel_loop = None
+        self.single_file_to_process = None
 
     def _segment_3d_volumes(self, image_3d, seg_params: SegmentationParams):
         if seg_params.stardist_basename is not None and os.path.exists(
@@ -256,6 +257,17 @@ class Mask3D:
                 in self.current_param.decode_file_parts(os.path.basename(x))["cycle"]
             )
         ]
+        if self.single_file_to_process:
+            self.filenames_to_process_list = [
+                x
+                for x in self.filenames_to_process_list
+                if os.path.basename(x) == os.path.basename(self.single_file_to_process)
+            ]
+            if not self.filenames_to_process_list:
+                raise SystemExit(
+                    f"Requested file '{self.single_file_to_process}' was not found"
+                    f" among the files to process in ROI [{roi_name}]."
+                )
         n_files_to_process = len(self.filenames_to_process_list)
         print_log(f"$ Found {n_files_to_process} files in ROI [{roi_name}]")
         print_log(
@@ -304,6 +316,7 @@ class Mask3D:
         seg_params,
         acq_params,
         reference_fiducial,
+        single_file_to_process=None,
     ):
         """
         segments 3D masks in root_folder
@@ -316,6 +329,8 @@ class Mask3D:
         session_name = "mask_3d"
 
         # processes folders and files
+
+        self.single_file_to_process = single_file_to_process
 
         print_session_name(session_name)
         write_string_to_file(

--- a/src/pyHiM.py
+++ b/src/pyHiM.py
@@ -115,6 +115,7 @@ def main(command_line_arguments=None):
                 datam.dict_shifts_path,
                 datam.acquisition_params,
                 registration_params,
+                single_file_to_process=run_args.input_file,
             )
         # [align masks in 3D]
         if "shift_mask" in pipe.cmds and (label in ("DAPI", "mask")):


### PR DESCRIPTION
## Summary
- allow SegmentMasks3D to limit processing to a user-specified file when the -I option is used
- propagate the input file argument through the pipeline so single-file runs raise helpful errors if the file is absent

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69300b0e09b08330acec8f4a7957ebf6)