### PR TITLE
Handle concurrent folder creation in data manager

### DIFF
--- a/src/core/data_manager.py
+++ b/src/core/data_manager.py
@@ -503,8 +503,10 @@ def create_folder(folder_path: str):
         Path name of folder
     """
 
-    if not os.path.exists(folder_path):
-        os.makedirs(folder_path)
-        print_log(f"$ Folder '{folder_path}' created successfully.")
-    else:
+    folder_already_exists = os.path.exists(folder_path)
+    os.makedirs(folder_path, exist_ok=True)
+
+    if folder_already_exists:
         print_log(f"! [INFO] Folder '{folder_path}' already exists.")
+    else:
+        print_log(f"$ Folder '{folder_path}' created successfully.")


### PR DESCRIPTION
## Summary
- make create_folder use os.makedirs with exist_ok to avoid race conditions during parallel runs
- retain logging while preventing FileExistsError when directories are created simultaneously

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693026f0ca1c8330995fd77a6a63e2de)