### PR TITLE
Load registration params for merge_inputs

### DIFF
--- a/src/core/function_caller.py
+++ b/src/core/function_caller.py
@@ -197,6 +197,7 @@ class Pipeline:
             "mask_3d",
             "shift_mask",
             "localize_3d",
+            "merge_inputs",
         }.intersection(set(self.cmds)):
             self.labelled_sections["barcode"].append("registration")
             self.labelled_sections["fiducial"].append("registration")


### PR DESCRIPTION
## Summary
- ensure registration parameters are loaded when merge_inputs is requested to avoid missing registration config

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69305c2247b48330875cd82756ba2fce)