### PR TITLE
Adjust default 3D stardist model selection

### DIFF
--- a/src/imageProcessing/segmentMasks3D.py
+++ b/src/imageProcessing/segmentMasks3D.py
@@ -51,7 +51,7 @@ class Mask3D:
         self.inner_parallel_loop = None
         self.single_file_to_process = None
 
-    def _segment_3d_volumes(self, image_3d, seg_params: SegmentationParams):
+    def _segment_3d_volumes(self, image_3d, seg_params: SegmentationParams, label: str):
         if seg_params.stardist_basename is not None and os.path.exists(
             seg_params.stardist_basename
         ):
@@ -63,12 +63,18 @@ class Mask3D:
                 "stardist_models",
             )
 
+        default_model_name = (
+            "DAPI_3D_stardist_17032021_deconvolved"
+            if "dapi" in label.lower()
+            else "PSF_3D_stardist_20210618_simu_deconvolved_thresh_0_01"
+        )
+
         if seg_params.stardist_network3D is not None and os.path.exists(
             os.path.join(base_dir, seg_params.stardist_network3D)
         ):
             model_name = seg_params.stardist_network3D
         else:
-            model_name = "DAPI_3D_stardist_17032021_deconvolved"
+            model_name = default_model_name
         binary, segmented_image_3d = _segment_3d_masks(
             image_3d,
             axis_norm=(0, 1, 2),
@@ -130,7 +136,9 @@ class Mask3D:
             }
 
         # segments 3D volumes
-        _, segmented_image_3d = self._segment_3d_volumes(image_3d, seg_params)
+        _, segmented_image_3d = self._segment_3d_volumes(
+            image_3d, seg_params, label
+        )
 
         number_masks = np.max(segmented_image_3d)
         print_log(f"$ Number of masks detected: {number_masks}")


### PR DESCRIPTION
## Summary
- choose default 3D stardist model based on whether the cycle label is DAPI or mask when a configured model is unavailable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69344db23d5483309d4a35ffbb288597)