### PR TITLE
Respect external CUDA device selection

### DIFF
--- a/src/imageProcessing/segmentMasks.py
+++ b/src/imageProcessing/segmentMasks.py
@@ -938,8 +938,9 @@ def _segment_3d_volumes_stardist(
     print_log("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
     print_log(f"> Segmenting {number_planes} planes using 1 worker...")
     print_log(f"> Loading model {model_name} from {model_dir}...")
-    #os.environ["CUDA_VISIBLE_DEVICES"] = "1"
-
+    print_log(
+        "> Using CUDA_VISIBLE_DEVICES from the environment; set it externally to pin GPUs."
+    )
     model = StarDist3D(None, name=model_name, basedir=model_dir)
     #limit_gpu_memory(None, allow_growth=True)
 
@@ -1107,8 +1108,9 @@ def _segment_3d_masks(
     print_log("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
     print_log(f"> Segmenting {number_planes} planes using 1 worker...")
     print_log(f"> Loading model {model_name} from {model_dir}...")
-    os.environ["CUDA_VISIBLE_DEVICES"] = "1"  # why do we need this?
-
+    print_log(
+        "> Using CUDA_VISIBLE_DEVICES from the environment; set it externally to pin GPUs."
+    )
     # Load the model
     # --------------
 


### PR DESCRIPTION
## Summary
- remove internal setting of CUDA_VISIBLE_DEVICES in 3D segmentation utilities
- log that GPU selection now follows the externally provided CUDA_VISIBLE_DEVICES environment variable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935473d6cf48330af4167e34724e41d)