### PR TITLE
Handle numbered mask cycles when selecting files

### DIFF
--- a/src/core/parameters.py
+++ b/src/core/parameters.py
@@ -165,10 +165,13 @@ class Parameters:
 
         # selects mask files
         elif self.param_dict["acquisition"]["label"] == "mask":
+            # Accept any mask cycle, including numbered ones such as "mask1"
             self.files_to_process = [
                 file
                 for file in files_folder
-                if len([i for i in file.split("_") if "mask" in i]) > 0
+                if self.decode_file_parts(path.basename(file))["cycle"].startswith(
+                    "mask"
+                )
                 and self.decode_file_parts(path.basename(file))["channel"]
                 == channel_mask
             ]


### PR DESCRIPTION
## Summary
- ensure mask file selection handles numbered mask cycles like mask1

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693d762b850883309db87f4df3e2dbeb)