### PR TITLE
Cines/tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 *pyHiM* implements the analysis of multiplexed DNA-FISH data, as described in our [Hi-M paper](https://www.nature.com/articles/s41596-019-0269-9).
 
+pyHiM has been published and is available as open-source here: pyHiM paper
+
 ## Documentation
 
 Find the full documentation in [ReadtheDocs](https://pyhim.readthedocs.io/en/stable/) and [tutorials](https://pyhim.readthedocs.io/en/stable/getting_started/tutorials.html) illustrating the main steps of pyHiM analysis pipeline.

--- a/docs/source/contributor/dev_installation.md
+++ b/docs/source/contributor/dev_installation.md
@@ -53,6 +53,28 @@ Run this command in your terminal:
 conda env create -f environment.yml
 ```
 
+### Verify GPU recognition
+
+After activating the conda environment, you can verify that TensorFlow detects your GPU by starting Python and running:
+
+```python
+import tensorflow as tf
+print(tf.__version__)
+print("Built with CUDA:", tf.test.is_built_with_cuda())
+print("Built with GPU support:", tf.test.is_built_with_gpu_support())
+print("Visible GPUs:", tf.config.list_physical_devices("GPU"))
+```
+
+### Selecting a GPU device
+
+If your machine has multiple GPUs, you can select which one pyHiM uses by setting `CUDA_VISIBLE_DEVICES` before launching the application. For example, to use device `2` on a machine with three GPUs, run the following in your shell prior to starting pyHiM:
+
+```bash
+export CUDA_VISIBLE_DEVICES=2
+```
+
+This environment variable limits visibility to the specified device index, letting you choose a different GPU than the default.
+
 ```{note}
 If you get this error:
 `ImportError: Dask\'s distributed scheduler is not installed.`

--- a/environment.yml
+++ b/environment.yml
@@ -12,10 +12,10 @@ dependencies:
   - libstdcxx-ng=11.2.0=h1234567_1
   - ncurses=6.4=h6a678d5_0
   - openssl=3.0.16=h5eee18b_0
-  - pip=25.0=py39h06a4308_0
+  - pip=25.3=py39h06a4308_0
   - python=3.9.21=he870216_1
   - readline=8.2=h5eee18b_0
-  - setuptools=75.8.0=py39h06a4308_0
+  - setuptools=78.1.1=py39h06a4308_0
   - sqlite=3.45.3=h5eee18b_0
   - tk=8.6.14=h39e8969_0
   - wheel=0.45.1=py39h06a4308_0
@@ -41,27 +41,6 @@ dependencies:
       - fsspec==2025.3.0
       - gast==0.6.0
       - google-pasta==0.2.0
-      - grpcio==1.71.0
-      - h5py==3.13.0
-      - idna==3.10
-      - imageio==2.37.0
-      - importlib-metadata==8.6.1
-      - iniconfig==2.1.0
-      - jinja2==3.1.6
-      - joblib==1.4.2
-      - keras==3.9.0
-      - kiwisolver==1.4.7
-      - libclang==18.1.1
-      - llvmlite==0.43.0
-      - locket==1.0.0
-      - markdown==3.7
-      - markdown-it-py==3.0.0
-      - markupsafe==3.0.2
-      - marshmallow==3.26.1
-      - matplotlib==3.5.1
-      - mdurl==0.1.2
-      - ml-dtypes==0.5.1
-      - mrc==0.3.1
       - msgpack==1.1.0
       - mypy-extensions==1.0.0
       - namex==0.0.8
@@ -87,7 +66,7 @@ dependencies:
       - pytz==2025.1
       - pywavelets==1.6.0
       - pyyaml==6.0.2
-      - requests==2.32.3
+      - requests==2.32.4
       - rich==13.9.4
       - roipoly==0.5.3
       - scikit-image==0.19.2
@@ -99,7 +78,7 @@ dependencies:
       - tblib==3.0.0
       - tensorboard==2.19.0
       - tensorboard-data-server==0.7.2
-      - tensorflow==2.19.0
+      - "tensorflow[and-cuda]==2.19.0"
       - tensorflow-addons==0.23.0
       - tensorflow-io-gcs-filesystem==0.37.1
       - termcolor==2.5.0
@@ -113,7 +92,7 @@ dependencies:
       - typing-extensions==4.12.2
       - typing-inspect==0.9.0
       - tzdata==2025.1
-      - urllib3==2.3.0
+      - urllib3==2.6.0
       - werkzeug==3.1.3
       - wrapt==1.17.2
       - zict==3.0.0

--- a/src/core/data_manager.py
+++ b/src/core/data_manager.py
@@ -503,8 +503,10 @@ def create_folder(folder_path: str):
         Path name of folder
     """
 
-    if not os.path.exists(folder_path):
-        os.makedirs(folder_path)
-        print_log(f"$ Folder '{folder_path}' created successfully.")
-    else:
+    folder_already_exists = os.path.exists(folder_path)
+    os.makedirs(folder_path, exist_ok=True)
+
+    if folder_already_exists:
         print_log(f"! [INFO] Folder '{folder_path}' already exists.")
+    else:
+        print_log(f"$ Folder '{folder_path}' created successfully.")

--- a/src/core/data_manager.py
+++ b/src/core/data_manager.py
@@ -72,6 +72,7 @@ class DataManager:
         self.m_data_path = self.__set_data_path(data_path)
         self.out_path = self.m_data_path
         self.md_log_file = md_file
+        self.logs_path = self._determine_logs_path(md_file)
         self.params_filename = "parameters"
         self.all_files = extract_files(self.m_data_path)
         self.param_file_path = self.find_param_file(param_file)
@@ -110,6 +111,11 @@ class DataManager:
     @staticmethod
     def __set_data_path(data_path):
         return str(data_path) if data_path else os.getcwd()
+
+    def _determine_logs_path(self, md_file: str):
+        logs_path = os.path.dirname(md_file) if md_file else os.path.join(self.m_data_path, "logs")
+        os.makedirs(logs_path, exist_ok=True)
+        return logs_path
 
     def find_param_file(self, param_file: str = None):
         """Find the user parameters file like `parameters.json` inside extracted input files.
@@ -368,7 +374,7 @@ class DataManager:
                         )
                     else:
                         dict_struct["common"][section][key] = val
-        save_json(dict_struct, os.path.join(self.m_data_path, "parameters_loaded.json"))
+        save_json(dict_struct, os.path.join(self.logs_path, "parameters_loaded.json"))
 
     def set_labelled_params(self, labelled_sections):
         print_session_name("Parameters initialisation")

--- a/src/core/function_caller.py
+++ b/src/core/function_caller.py
@@ -34,6 +34,7 @@ from imageProcessing.segmentMasks3D import Mask3D
 from imageProcessing.segmentSources3D import Localize3D
 from matrixOperations.build_matrix_tempo import BuildMatrixTempo
 from matrixOperations.build_traces import BuildTraces, BuildTracesTempo
+from matrixOperations.merge_inputs import MergeInputs
 from matrixOperations.filter_localizations import (
     FilterLocalizations,
     FilterLocalizationsTempo,
@@ -142,6 +143,15 @@ class Pipeline:
             ]:
                 cmds.append("register_localizations")
             elif cmd.lower() in [
+                "merge_inputs",
+                "mergeinputs",
+                "merge_traces_inputs",
+                "mergetracesinputs",
+                "merge_traces",
+                "mergetraces",
+            ]:
+                cmds.append("merge_inputs")
+            elif cmd.lower() in [
                 "build_traces",
                 "build_trace",
                 "buildtrace",
@@ -202,6 +212,7 @@ class Pipeline:
             "localize_3d",
             "filter_localizations",
             "register_localizations",
+            "merge_inputs",
             "build_traces",
         }.intersection(set(self.cmds)):
             self.labelled_sections["barcode"].append("segmentation")
@@ -256,6 +267,8 @@ class Pipeline:
         if "localize_3d" in self.cmds:
             self._init_labelled_feature(localize_3d.Localize3D, "segmentation")
             ordered_routines.append("localize_3d")
+        if "merge_inputs" in self.cmds:
+            ordered_routines.append("merge_inputs")
         if "filter_localizations" in self.cmds:
             self._init_labelled_feature(FilterLocalizationsTempo, "matrix")
             ordered_routines.append("filter_localizations")
@@ -587,6 +600,21 @@ def register_localizations(
         register_localizations_instance.register(
             data_path, local_shifts_path, segmentation_params, reg_params
         )
+
+
+def merge_inputs(
+    current_param,
+    label,
+    data_path,
+    segmentation_params: SegmentationParams,
+    reg_params: RegistrationParams,
+):
+    """Merge localization and registration tables prior to trace building."""
+
+    if label == "barcode":
+        merger = MergeInputs(current_param)
+        return merger.merge_all(data_path, segmentation_params, reg_params)
+    return None
 
 
 def build_traces(

--- a/src/core/function_caller.py
+++ b/src/core/function_caller.py
@@ -359,6 +359,7 @@ class Pipeline:
         dict_shifts_path,
         acq_params: AcquisitionParams,
         reg_params: RegistrationParams,
+        single_file_to_process=None,
     ):
         if (label in ("DAPI", "mask")) and "3D" in current_param.param_dict[
             "segmentedObjects"
@@ -377,6 +378,7 @@ class Pipeline:
                 segmentation_params,
                 acq_params,
                 reg_params.referenceFiducial,
+                single_file_to_process=single_file_to_process,
             )
 
     def shift_mask(

--- a/src/core/function_caller.py
+++ b/src/core/function_caller.py
@@ -47,7 +47,7 @@ from matrixOperations.register_localizations import (
 class Pipeline:
     """Class for high level function calling"""
 
-    def __init__(self, data_m, cmd_list, is_parallel, logger):
+    def __init__(self, data_m, cmd_list, is_parallel, logger, input_file=None):
         self.m_data_m = data_m
         self.cmds = self.interpret_cmd_list(cmd_list)
         self.set_params_from_cmds()
@@ -55,6 +55,7 @@ class Pipeline:
         self.m_logger = logger
         self.m_dask = None
         self.features = []
+        self.input_file = input_file
         self.init_features()
 
     def interpret_cmd_list(self, cmd_list):
@@ -430,7 +431,10 @@ class Pipeline:
                 parallel=self.parallel,
             )
             _segment_sources_3d.segment_sources_3d(
-                data_path, dict_shifts_path, segmentation_params
+                data_path,
+                dict_shifts_path,
+                segmentation_params,
+                single_file_to_process=self.input_file,
             )
 
     def run(self):  # sourcery skip: remove-pass-body

--- a/src/core/function_caller.py
+++ b/src/core/function_caller.py
@@ -197,6 +197,7 @@ class Pipeline:
             "mask_3d",
             "shift_mask",
             "localize_3d",
+            "merge_inputs",
         }.intersection(set(self.cmds)):
             self.labelled_sections["barcode"].append("registration")
             self.labelled_sections["fiducial"].append("registration")

--- a/src/core/function_caller.py
+++ b/src/core/function_caller.py
@@ -299,6 +299,7 @@ class Pipeline:
         dict_shifts_path,
         roi_name,
         z_binning,
+        single_file_to_process=None,
     ):
         if label == "fiducial" and registration_params.localAlignment == "block3D":
             print_log(f"> Making 3D image registrations label: {label}")
@@ -306,7 +307,12 @@ class Pipeline:
                 current_param, registration_params, parallel=self.parallel
             )
             local_shifts_path = _drift_3d.align_fiducials_3d(
-                data_path, registration_params, dict_shifts_path, roi_name, z_binning
+                data_path,
+                registration_params,
+                dict_shifts_path,
+                roi_name,
+                z_binning,
+                single_file_to_process=single_file_to_process,
             )
             self.m_data_m.local_shifts_path = local_shifts_path
 

--- a/src/core/parameters.py
+++ b/src/core/parameters.py
@@ -133,7 +133,7 @@ class Parameters:
                 status="WARN",
             )
 
-        print_log(f'>>> label: {self.param_dict["acquisition"]["label"]}" == mask')
+        print_log(f'>>> label: {self.param_dict["acquisition"]["label"]} == mask')
         # selects DAPI files
         if self.param_dict["acquisition"]["label"] == "DAPI":
             self.files_to_process = [

--- a/src/core/parameters.py
+++ b/src/core/parameters.py
@@ -133,6 +133,7 @@ class Parameters:
                 status="WARN",
             )
 
+        print_log(f'>>> label: {self.param_dict["acquisition"]["label"]}" == mask')
         # selects DAPI files
         if self.param_dict["acquisition"]["label"] == "DAPI":
             self.files_to_process = [

--- a/src/core/parameters.py
+++ b/src/core/parameters.py
@@ -165,6 +165,7 @@ class Parameters:
 
         # selects mask files
         elif self.param_dict["acquisition"]["label"] == "mask":
+            print_log(">>> entered mask selection")
             # Accept any mask cycle, including numbered ones such as "mask1"
             self.files_to_process = [
                 file
@@ -175,6 +176,12 @@ class Parameters:
                 and self.decode_file_parts(path.basename(file))["channel"]
                 == channel_mask
             ]
+            for file in files_folder:
+                print_log(
+                    f'>>> file: {file}\n cycle: \
+                          {self.decode_file_parts(path.basename(file))["cycle"]}\n \
+                            channel: {self.decode_file_parts(path.basename(file))["channel"]}\n channel_mask: {channel_mask}'
+                )
 
         # selects fiducial files
         elif self.param_dict["acquisition"]["label"] == "fiducial":

--- a/src/core/parameters.py
+++ b/src/core/parameters.py
@@ -165,10 +165,13 @@ class Parameters:
 
         # selects mask files
         elif self.param_dict["acquisition"]["label"] == "mask":
+            # Accept any mask cycle, including numbered ones such as "mask1"
             self.files_to_process = [
                 file
                 for file in files_folder
-                if len([i for i in file.split("_") if "mask" in i]) > 0
+                if self.decode_file_parts(path.basename(file))["cycle"].startswith(
+                    "mask"
+                )
                 and self.decode_file_parts(path.basename(file))["channel"]
                 == channel_mask
             ]

--- a/src/core/pyhim_logging.py
+++ b/src/core/pyhim_logging.py
@@ -6,6 +6,7 @@ Classes and functions for pyHiM logging
 
 import logging
 import os
+import uuid
 from datetime import datetime
 
 from dask.distributed.worker import logger
@@ -19,6 +20,7 @@ class Logger:
         self, root_folder, parallel=False, session_name="HiM_analysis", init_msg=""
     ):
         self.m_root_folder = root_folder
+        self.logs_path = ""
         self.log_file = ""
         self.md_filename = ""
         # Keeps the messages to be print in log until this is possible
@@ -33,8 +35,14 @@ class Logger:
         begin_time = datetime.now()
         now = datetime.now()
         date_time = now.strftime("%d%m%Y_%H%M%S")
+        unique_id = uuid.uuid4().hex
 
-        self.log_file = self.m_root_folder + os.sep + session_name + date_time + ".log"
+        self.logs_path = os.path.join(self.m_root_folder, "logs")
+        os.makedirs(self.logs_path, exist_ok=True)
+
+        self.log_file = os.path.join(
+            self.logs_path, f"{session_name}{date_time}_{unique_id}.log"
+        )
         self.md_filename = self.log_file.split(".")[0] + ".md"
         self.init_msg += f"$ {session_name} will be written to: {self.md_filename}"
 

--- a/src/core/run_args.py
+++ b/src/core/run_args.py
@@ -55,6 +55,16 @@ def _parse_run_args(command_line_arguments):
         help="Thread number to run with parallel mode.\nDEFAULT: 1 (sequential mode)",
     )
 
+    parser.add_argument(
+        "-I",
+        "--inputFile",
+        type=str,
+        default=None,
+        help="Optional name of a single image file to process. When provided,\n"
+        "        pyHiM will restrict processing to this file (when compatible\n"
+        "        with the selected command).",
+    )
+
     return parser.parse_args(command_line_arguments)
 
 
@@ -72,6 +82,7 @@ class RunArgs:
         self.thread_nbr = parsed_args.threads
         self.parallel = self.thread_nbr > 1
         self.params_path = parsed_args.parameters
+        self.input_file = parsed_args.inputFile
         self._check_consistency()
 
     def _is_docker(self):
@@ -124,6 +135,8 @@ class RunArgs:
         to_print += tab_spacer("threads", str(self.thread_nbr))
         to_print += tab_spacer("parallel", str(self.parallel))
         to_print += tab_spacer("cmd", str(self.cmd_list))
+        if self.input_file:
+            to_print += tab_spacer("inputFile", str(self.input_file))
 
         return to_print
 

--- a/src/core/run_args.py
+++ b/src/core/run_args.py
@@ -193,6 +193,7 @@ class RunArgs:
             "shift_mask",
             "filter_localizations",
             "register_localizations",
+            "merge_inputs",
             "build_traces",
             "build_matrix",
         )

--- a/src/core/run_args.py
+++ b/src/core/run_args.py
@@ -60,9 +60,11 @@ def _parse_run_args(command_line_arguments):
         "--inputFile",
         type=str,
         default=None,
-        help="Optional name of a single image file to process. When provided,\n"
-        "        pyHiM will restrict processing to this file (when compatible\n"
-        "        with the selected command).",
+        help=(
+            "Optional name of a single image file to process. When provided,\n"
+            "pyHiM will restrict processing to this file (when compatible\n"
+            "with the selected command)."
+        ),
     )
 
     return parser.parse_args(command_line_arguments)

--- a/src/imageProcessing/alignImages3D.py
+++ b/src/imageProcessing/alignImages3D.py
@@ -177,6 +177,7 @@ class Drift3D:
         params: RegistrationParams,
         roi_name,
         z_binning,
+        single_file_to_process=None,
     ):
         """
         Refits all the barcode files found in root_folder
@@ -214,6 +215,16 @@ class Drift3D:
             for x in self.current_param.files_to_process
             if (x != self.filenames_with_ref_barcode)
         ]
+        if single_file_to_process:
+            self.filenames_to_process_list = [
+                x
+                for x in self.filenames_to_process_list
+                if os.path.basename(x) == os.path.basename(single_file_to_process)
+            ]
+            if not self.filenames_to_process_list:
+                raise SystemExit(
+                    f"Requested file '{single_file_to_process}' was not found among the files to process."
+                )
         number_files = len(self.filenames_to_process_list)
 
         if client is None:
@@ -259,12 +270,20 @@ class Drift3D:
 
             # del futures
 
-        # Merges Tables for different cycles and appends results Table to that of previous ROI
-        alignment_results_table_global = vstack(
-            [alignment_results_table_global] + alignment_results_tables
-        )
+        output_prefix = params.outputFile
+        if single_file_to_process:
+            output_prefix = (
+                output_prefix
+                + "_"
+                + os.path.splitext(os.path.basename(single_file_to_process))[0]
+            )
 
-        # saves Table with all shifts
+        if single_file_to_process and alignment_results_tables:
+            alignment_results_table_global = alignment_results_tables[0]
+        else:
+            alignment_results_table_global = vstack(
+                [alignment_results_table_global] + alignment_results_tables
+            )
 
         path_name = (
             data_path
@@ -273,7 +292,7 @@ class Drift3D:
             + os.sep
             + "data"
             + os.sep
-            + params.outputFile
+            + output_prefix
         )
         local_shifts_path = path_name + "_block3D.dat"
 
@@ -295,6 +314,7 @@ class Drift3D:
         dict_shifts_path,
         roi_name,
         z_binning,
+        single_file_to_process=None,
     ):
         """
         runs refitting routine in root_folder
@@ -313,7 +333,12 @@ class Drift3D:
         # self.current_log.parallel = self.parallel
 
         local_shifts_path = self.align_fiducials_3d_in_folder(
-            data_path, dict_shifts_path, params, roi_name, z_binning
+            data_path,
+            dict_shifts_path,
+            params,
+            roi_name,
+            z_binning,
+            single_file_to_process=single_file_to_process,
         )
 
         print_log(f"HiM matrix in {data_path} processed")

--- a/src/imageProcessing/segmentMasks.py
+++ b/src/imageProcessing/segmentMasks.py
@@ -938,10 +938,10 @@ def _segment_3d_volumes_stardist(
     print_log("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
     print_log(f"> Segmenting {number_planes} planes using 1 worker...")
     print_log(f"> Loading model {model_name} from {model_dir}...")
-    os.environ["CUDA_VISIBLE_DEVICES"] = "1"
+    #os.environ["CUDA_VISIBLE_DEVICES"] = "1"
 
     model = StarDist3D(None, name=model_name, basedir=model_dir)
-    limit_gpu_memory(None, allow_growth=True)
+    #limit_gpu_memory(None, allow_growth=True)
 
     im = normalize(image_3d, 1, 99.8, axis=axis_norm)
     l_x = im.shape[1]

--- a/src/imageProcessing/segmentMasks.py
+++ b/src/imageProcessing/segmentMasks.py
@@ -938,8 +938,9 @@ def _segment_3d_volumes_stardist(
     print_log("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
     print_log(f"> Segmenting {number_planes} planes using 1 worker...")
     print_log(f"> Loading model {model_name} from {model_dir}...")
-    #os.environ["CUDA_VISIBLE_DEVICES"] = "1"
-
+    print_log(
+        "> Using CUDA_VISIBLE_DEVICES from the environment; set it externally to pin GPUs."
+    )
     model = StarDist3D(None, name=model_name, basedir=model_dir)
     #limit_gpu_memory(None, allow_growth=True)
 
@@ -1107,8 +1108,9 @@ def _segment_3d_masks(
     print_log("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
     print_log(f"> Segmenting {number_planes} planes using 1 worker...")
     print_log(f"> Loading model {model_name} from {model_dir}...")
-    os.environ["CUDA_VISIBLE_DEVICES"] = "1"  # why do we need this?
-
+    print_log(
+        "> Using CUDA_VISIBLE_DEVICES from the environment; set it externally to pin GPUs."
+    )
     # Load the model
     # --------------
 

--- a/src/imageProcessing/segmentMasks3D.py
+++ b/src/imageProcessing/segmentMasks3D.py
@@ -49,6 +49,7 @@ class Mask3D:
         self.dict_shifts_available = None
         self.filenames_to_process_list = []
         self.inner_parallel_loop = None
+        self.single_file_to_process = None
 
     def _segment_3d_volumes(self, image_3d, seg_params: SegmentationParams):
         if seg_params.stardist_basename is not None and os.path.exists(
@@ -256,6 +257,17 @@ class Mask3D:
                 in self.current_param.decode_file_parts(os.path.basename(x))["cycle"]
             )
         ]
+        if self.single_file_to_process:
+            self.filenames_to_process_list = [
+                x
+                for x in self.filenames_to_process_list
+                if os.path.basename(x) == os.path.basename(self.single_file_to_process)
+            ]
+            if not self.filenames_to_process_list:
+                raise SystemExit(
+                    f"Requested file '{self.single_file_to_process}' was not found"
+                    f" among the files to process in ROI [{roi_name}]."
+                )
         n_files_to_process = len(self.filenames_to_process_list)
         print_log(f"$ Found {n_files_to_process} files in ROI [{roi_name}]")
         print_log(
@@ -304,6 +316,7 @@ class Mask3D:
         seg_params,
         acq_params,
         reference_fiducial,
+        single_file_to_process=None,
     ):
         """
         segments 3D masks in root_folder
@@ -316,6 +329,8 @@ class Mask3D:
         session_name = "mask_3d"
 
         # processes folders and files
+
+        self.single_file_to_process = single_file_to_process
 
         print_session_name(session_name)
         write_string_to_file(

--- a/src/imageProcessing/segmentMasks3D.py
+++ b/src/imageProcessing/segmentMasks3D.py
@@ -51,7 +51,7 @@ class Mask3D:
         self.inner_parallel_loop = None
         self.single_file_to_process = None
 
-    def _segment_3d_volumes(self, image_3d, seg_params: SegmentationParams):
+    def _segment_3d_volumes(self, image_3d, seg_params: SegmentationParams, label: str):
         if seg_params.stardist_basename is not None and os.path.exists(
             seg_params.stardist_basename
         ):
@@ -63,12 +63,18 @@ class Mask3D:
                 "stardist_models",
             )
 
+        default_model_name = (
+            "DAPI_3D_stardist_17032021_deconvolved"
+            if "dapi" in label.lower()
+            else "PSF_3D_stardist_20210618_simu_deconvolved_thresh_0_01"
+        )
+
         if seg_params.stardist_network3D is not None and os.path.exists(
             os.path.join(base_dir, seg_params.stardist_network3D)
         ):
             model_name = seg_params.stardist_network3D
         else:
-            model_name = "DAPI_3D_stardist_17032021_deconvolved"
+            model_name = default_model_name
         binary, segmented_image_3d = _segment_3d_masks(
             image_3d,
             axis_norm=(0, 1, 2),
@@ -130,7 +136,9 @@ class Mask3D:
             }
 
         # segments 3D volumes
-        _, segmented_image_3d = self._segment_3d_volumes(image_3d, seg_params)
+        _, segmented_image_3d = self._segment_3d_volumes(
+            image_3d, seg_params, label
+        )
 
         number_masks = np.max(segmented_image_3d)
         print_log(f"$ Number of masks detected: {number_masks}")

--- a/src/imageProcessing/segmentSources3D.py
+++ b/src/imageProcessing/segmentSources3D.py
@@ -123,12 +123,8 @@ class Localize3D:
                 os.pardir,
                 "stardist_models",
             )
-        if seg_params.stardist_network3D is not None and os.path.exists(
-            os.path.join(base_dir, seg_params.stardist_network3D)
-        ):
-            model_name = seg_params.stardist_network3D
-        else:
-            model_name = "PSF_3D_stardist_20210618_simu_deconvolved_thresh_0_01"
+
+        model_name = self._select_stardist_model(None, seg_params, base_dir)
         self.p["stardist_basename"] = base_dir
         self.p["stardist_network"] = model_name
         # parameters used for 3D gaussian fitting
@@ -144,6 +140,27 @@ class Localize3D:
         # parameters used for plotting 3D image
         # sets the number of planes around the center of the image used to represent localizations in XZ and ZY
         self.p["windowDisplay"] = 10
+
+    def _select_stardist_model(
+        self, label: Optional[str], seg_params: SegmentationParams, base_dir: str
+    ) -> str:
+        """Return the appropriate Stardist model name based on the label.
+
+        If a custom network is configured and present on disk it is used.
+        Otherwise, fall back to label-specific defaults.
+        """
+
+        if seg_params.stardist_network3D is not None:
+            candidate_path = os.path.join(base_dir, seg_params.stardist_network3D)
+            if os.path.exists(candidate_path):
+                return seg_params.stardist_network3D
+
+        if label == "DAPI":
+            return "DAPI_3D_stardist_17032021_deconvolved"
+        if label == "mask":
+            return "PSF_3D_stardist_20210618_simu_deconvolved_thresh_0_01"
+
+        return "PSF_3D_stardist_20210618_simu_deconvolved_thresh_0_01"
 
     def plot_image_3d(self, image_3d, localizations=None, masks=None, normalize_b=None):
         """
@@ -207,6 +224,10 @@ class Localize3D:
             self.current_param.decode_file_parts(os.path.basename(filename_to_process))[
                 "cycle"
             ]
+        )
+
+        self.p["stardist_network"] = self._select_stardist_model(
+            label, seg_params, self.p["stardist_basename"]
         )
 
         # creates Table that will hold results

--- a/src/imageProcessing/segmentSources3D.py
+++ b/src/imageProcessing/segmentSources3D.py
@@ -29,6 +29,7 @@ import glob
 import os
 import uuid
 from datetime import datetime
+from typing import Optional
 
 import numpy as np
 from apifish.identification.spot_modeling import fit_subpixel
@@ -83,6 +84,7 @@ class Localize3D:
         self.filenames_to_process_list = []
         self.inner_parallel_loop = None
         self.output_filename = None
+        self.single_file_to_process = None
 
         # parameters from parameters.json
         self.p["referenceBarcode"] = reg_params.referenceFiducial
@@ -434,6 +436,18 @@ class Localize3D:
             in self.current_param.decode_file_parts(os.path.basename(x))["cycle"]
         ]
 
+        if self.single_file_to_process:
+            self.filenames_to_process_list = [
+                x
+                for x in self.filenames_to_process_list
+                if os.path.basename(x) == self.single_file_to_process
+            ]
+            if not self.filenames_to_process_list:
+                raise SystemExit(
+                    f"Requested file '{self.single_file_to_process}' was not found"
+                    f" among the files to process in ROI [{self.roi}]."
+                )
+
         n_files_to_process = len(self.filenames_to_process_list)
         print_log(f"$ Found {n_files_to_process} files in ROI [{self.roi}]")
         print_log(
@@ -498,7 +512,11 @@ class Localize3D:
         )
 
     def segment_sources_3d(
-        self, data_path, dict_shifts_path, params: SegmentationParams
+        self,
+        data_path,
+        dict_shifts_path,
+        params: SegmentationParams,
+        single_file_to_process: Optional[str] = None,
     ):
         """
         runs 3D fitting routine in root_folder
@@ -520,6 +538,14 @@ class Localize3D:
         )
 
         # creates output folders and filenames
+        self.single_file_to_process = single_file_to_process
+        output_file_prefix = params.outputFile
+        if self.single_file_to_process:
+            base_name = os.path.splitext(
+                os.path.basename(self.single_file_to_process)
+            )[0]
+            output_file_prefix = f"{output_file_prefix}_{base_name}"
+
         self.output_filename = (
             data_path
             + os.sep
@@ -527,7 +553,7 @@ class Localize3D:
             + os.sep
             + "data"
             + os.sep
-            + params.outputFile
+            + output_file_prefix
             + "_3D_barcode.dat"
         )
 

--- a/src/matrixOperations/build_traces.py
+++ b/src/matrixOperations/build_traces.py
@@ -797,29 +797,17 @@ class BuildTraces:
 
         print_log(f"> Masks labels: {matrix_params.masks2process}")
 
-        # iterates over barcode localization tables in the current folder
-        data_file_base_2d = (
-            data_path
-            + os.sep
-            + seg_params.localize_2d_folder
-            + os.sep
-            + "data"
-            + os.sep
-            + seg_params.outputFile
-        )
-        data_file_base_3d = (
-            data_path
-            + os.sep
-            + seg_params.localize_3d_folder
-            + os.sep
-            + "data"
-            + os.sep
-            + seg_params.outputFile
-        )
-        files = list(glob.glob(data_file_base_2d + "_*" + self.label + ".dat"))
-        files += list(glob.glob(data_file_base_3d + "_*" + self.label + ".dat"))
-        # remove duplicate path, it's possible for example if 2d and 3d folder have same name
-        files = list(set(files))
+        # iterates over consolidated barcode localization tables in the current folder
+        files = []
+        for folder, suffix in (
+            (seg_params.localize_2d_folder, "_2D_barcode.dat"),
+            (seg_params.localize_3d_folder, "_3D_barcode.dat"),
+        ):
+            consolidated_path = os.path.join(
+                data_path, folder, "data", f"{seg_params.outputFile}{suffix}"
+            )
+            if os.path.exists(consolidated_path):
+                files.append(consolidated_path)
         if not files:
             print_log("$ No localization table found to process!", "WARN")
             return

--- a/src/matrixOperations/filter_localizations.py
+++ b/src/matrixOperations/filter_localizations.py
@@ -155,8 +155,10 @@ class FilterLocalizations:
             + os.sep
             + seg_params.outputFile
         )
-        files = list(glob.glob(data_file_base_2d + "_*barcode.dat"))
-        files += list(glob.glob(data_file_base_3d + "_*barcode.dat"))
+#        files = list(glob.glob(data_file_base_2d + "_*barcode.dat"))
+#        files += list(glob.glob(data_file_base_3d + "_*barcode.dat"))
+        files = list(glob.glob(data_file_base_2d + "_2D_barcode.dat"))
+        files += list(glob.glob(data_file_base_3d + "_3D_barcode.dat"))
         if files:
             for file in files:
                 self.ndims = 3 if "3D" in os.path.basename(file) else 2

--- a/src/matrixOperations/merge_inputs.py
+++ b/src/matrixOperations/merge_inputs.py
@@ -53,8 +53,17 @@ class MergeInputs:
             return False
 
         merged_table = vstack(tables, metadata_conflicts="silent")
+
+        merged_table.meta["comments"] = [""]
+
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
-        merged_table.write(output_path, format="ascii.ecsv", overwrite=True)
+
+        merged_table.write(
+            output_path,
+            format="ascii.ecsv",
+            overwrite=True,
+        )
+                
         print_log(
             f"$ Merged {len(tables)} {description} table(s) into: {output_path}"
         )

--- a/src/matrixOperations/merge_inputs.py
+++ b/src/matrixOperations/merge_inputs.py
@@ -1,0 +1,126 @@
+"""Utilities to merge localization and registration tables prior to trace building.
+
+This module consolidates multiple per-image outputs from ``SegmentSources3D``
+and ``register_local`` into the single-file convention expected by
+``build_traces``. When the aggregated file already exists, the merger exits
+without modifying the data.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+from typing import Iterable, Optional
+
+from astropy.table import Table, vstack
+
+from core.parameters import RegistrationParams, SegmentationParams
+from core.pyhim_logging import print_log
+
+
+class MergeInputs:
+    """Merge localization and registration tables before trace building."""
+
+    def __init__(self, param):
+        self.current_param = param
+
+    def _merge_tables(
+        self,
+        files: Iterable[str],
+        output_path: str,
+        description: str,
+    ) -> bool:
+        """Merge a collection of ECSV tables into a single file.
+
+        Parameters
+        ----------
+        files
+            Iterable of table paths to merge.
+        output_path
+            Destination file path following the build_traces naming convention.
+        description
+            Human-friendly label used in log messages.
+
+        Returns
+        -------
+        bool
+            ``True`` when a merged file is written, ``False`` otherwise.
+        """
+
+        tables = [Table.read(path, format="ascii.ecsv") for path in files]
+        if not tables:
+            print_log(f"! No {description} tables found to merge.")
+            return False
+
+        merged_table = vstack(tables, metadata_conflicts="silent")
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        merged_table.write(output_path, format="ascii.ecsv", overwrite=True)
+        print_log(
+            f"$ Merged {len(tables)} {description} table(s) into: {output_path}"
+        )
+        return True
+
+    def merge_localization_tables(
+        self, data_path: str, seg_params: SegmentationParams
+    ) -> None:
+        """Merge per-file localization tables into the expected filenames."""
+
+        for folder, suffix in (
+            (seg_params.localize_2d_folder, "_2D_barcode.dat"),
+            (seg_params.localize_3d_folder, "_3D_barcode.dat"),
+        ):
+            output_path = os.path.join(
+                data_path, folder, "data", f"{seg_params.outputFile}{suffix}"
+            )
+            if os.path.exists(output_path):
+                print_log(
+                    f"$ Localization file already present: {output_path}\n> Nothing to merge."
+                )
+                continue
+            pattern = os.path.join(
+                data_path, folder, "data", f"{seg_params.outputFile}_*{suffix}"
+            )
+            files = sorted(glob.glob(pattern))
+            self._merge_tables(files, output_path, "localization")
+
+    def merge_registration_tables(
+        self, data_path: str, reg_params: RegistrationParams
+    ) -> Optional[str]:
+        """Merge per-file local registration tables.
+
+        Returns the path of the merged registration file when created, otherwise
+        ``None``.
+        """
+
+        output_path = os.path.join(
+            data_path,
+            reg_params.register_local_folder,
+            "data",
+            f"{reg_params.outputFile}_block3D.dat",
+        )
+        if os.path.exists(output_path):
+            print_log(
+                f"$ Registration file already present: {output_path}\n> Nothing to merge."
+            )
+            return output_path
+
+        pattern = os.path.join(
+            data_path,
+            reg_params.register_local_folder,
+            "data",
+            f"{reg_params.outputFile}_*_block3D.dat",
+        )
+        files = sorted(glob.glob(pattern))
+        merged = self._merge_tables(files, output_path, "registration")
+        return output_path if merged else None
+
+    def merge_all(
+        self, data_path: str, seg_params: SegmentationParams, reg_params: RegistrationParams
+    ) -> Optional[str]:
+        """Merge both localization and registration tables.
+
+        Returns the merged registration file path when one is created.
+        """
+
+        self.merge_localization_tables(data_path, seg_params)
+        return self.merge_registration_tables(data_path, reg_params)

--- a/src/matrixOperations/register_localizations.py
+++ b/src/matrixOperations/register_localizations.py
@@ -438,9 +438,11 @@ class RegisterLocalizations:
             + os.sep
             + seg_params.outputFile
         )
-        files = list(glob.glob(data_file_base_2d + "_*" + label + ".dat"))
-        files += list(glob.glob(data_file_base_3d + "_*" + label + ".dat"))
-
+#        files = list(glob.glob(data_file_base_2d + "_*" + label + ".dat"))
+#        files += list(glob.glob(data_file_base_3d + "_*" + label + ".dat"))
+        files = list(glob.glob(data_file_base_2d + "_2D_barcode.dat"))
+        files += list(glob.glob(data_file_base_3d + "_3D_barcode.dat"))
+        
         if not files:
             print_log("No localization table found to process!")
             return

--- a/src/pyHiM.py
+++ b/src/pyHiM.py
@@ -115,6 +115,7 @@ def main(command_line_arguments=None):
                 datam.dict_shifts_path,
                 datam.acquisition_params,
                 registration_params,
+                single_file_to_process=run_args.input_file,
             )
         # [align masks in 3D]
         if "shift_mask" in pipe.cmds and (label in ("DAPI", "mask")):

--- a/src/pyHiM.py
+++ b/src/pyHiM.py
@@ -39,7 +39,9 @@ def main(command_line_arguments=None):
         param_file=run_args.params_path,
     )
 
-    pipe = fc.Pipeline(datam, run_args.cmd_list, run_args.parallel, logger)
+    pipe = fc.Pipeline(
+        datam, run_args.cmd_list, run_args.parallel, logger, run_args.input_file
+    )
     pipe.lauch_dask_scheduler(threads_requested=run_args.thread_nbr, maximum_load=0.8)
 
     pipe.run()

--- a/src/pyHiM.py
+++ b/src/pyHiM.py
@@ -172,6 +172,20 @@ def main(command_line_arguments=None):
                 matrix_params,
             )
 
+        # [merge localization and registration tables before building traces]
+        if "merge_inputs" in pipe.cmds and label == "barcode":
+            segmentation_params = datam.labelled_params[label].segmentation
+            registration_params = datam.labelled_params[label].registration
+            merged_local_shifts = fc.merge_inputs(
+                current_param,
+                label,
+                datam.m_data_path,
+                segmentation_params,
+                registration_params,
+            )
+            if merged_local_shifts:
+                datam.local_shifts_path = merged_local_shifts
+
         # [registers barcode localization table]
         if "register_localizations" in pipe.cmds and label == "barcode":
             registration_params = datam.labelled_params[label].registration

--- a/src/pyHiM.py
+++ b/src/pyHiM.py
@@ -86,6 +86,7 @@ def main(command_line_arguments=None):
                 datam.dict_shifts_path,
                 datam.processed_roi,
                 datam.acquisition_params.zBinning,
+                single_file_to_process=run_args.input_file,
             )
 
         # [segments DAPI and sources in 2D]

--- a/src/pyHiM.py
+++ b/src/pyHiM.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 """Main file of pyHiM, include the top-level mechanism."""
 
-from datetime import datetime
-
 import core.function_caller as fc
 from _version import __version__
 from core.data_manager import DataManager
@@ -22,8 +20,6 @@ def main(command_line_arguments=None):
         For example, to test the pyHiM run from tests folder.
         By default None.
     """
-    begin_time = datetime.now()
-
     run_args = RunArgs(command_line_arguments)
 
     logger = Logger(
@@ -235,6 +231,7 @@ def main(command_line_arguments=None):
         pipe.m_dask.client.close()
 
     del pipe
+
 
 def _log_available_gpus():
     try:

--- a/src/toolbox/file_handling/zipHiM_run.py
+++ b/src/toolbox/file_handling/zipHiM_run.py
@@ -51,14 +51,22 @@ def main():
     TAR_FILENAME = "HiMrun.tar"
     print(f"creating archive: {TAR_FILENAME} in {root_folder}")
 
-    # tar files in root_folder
-    markdown_files = [
-        os.path.basename(f) for f in glob.glob(root_folder + os.sep + "*.md")
-    ]
-    log_files = [os.path.basename(f) for f in glob.glob(root_folder + os.sep + "*.log")]
-    session_files = [
-        os.path.basename(f) for f in glob.glob(root_folder + os.sep + "*.json")
-    ]
+    def collect_files(search_dirs, pattern):
+        files = []
+        for directory in search_dirs:
+            files.extend(
+                [os.path.relpath(f, root_folder) for f in glob.glob(directory + os.sep + pattern)]
+            )
+        return files
+
+    search_dirs = [root_folder]
+    logs_dir = root_folder + os.sep + "logs"
+    if os.path.isdir(logs_dir):
+        search_dirs.insert(0, logs_dir)
+
+    markdown_files = collect_files(search_dirs, "*.md")
+    log_files = collect_files(search_dirs, "*.log")
+    session_files = collect_files(search_dirs, "*.json")
 
     TARCMD = (
         "tar -cvf "

--- a/tests/test_merge_inputs.py
+++ b/tests/test_merge_inputs.py
@@ -1,0 +1,90 @@
+import pytest
+
+pytest.importorskip("astropy")
+
+from types import SimpleNamespace
+
+from astropy.table import Table
+
+from matrixOperations.merge_inputs import MergeInputs
+
+
+def _write_dummy_table(path, value):
+    table = Table({"ROI #": [value]})
+    table.write(path, format="ascii.ecsv", overwrite=True)
+
+
+def test_merge_inputs_creates_expected_outputs(tmp_path):
+    data_path = tmp_path
+    seg_params = SimpleNamespace(
+        localize_2d_folder="localize_2d",
+        localize_3d_folder="localize_3d",
+        outputFile="localizations",
+    )
+    reg_params = SimpleNamespace(
+        register_local_folder="register_local", outputFile="shifts"
+    )
+
+    for folder, suffix, values in (
+        (seg_params.localize_3d_folder, "_3D_barcode.dat", [1, 2]),
+        (reg_params.register_local_folder, "_block3D.dat", [3, 4]),
+    ):
+        for idx, val in enumerate(values):
+            file_path = (
+                data_path
+                / folder
+                / "data"
+                / f"{seg_params.outputFile if 'barcode' in suffix else reg_params.outputFile}_{idx}{suffix}"
+            )
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            _write_dummy_table(file_path, val)
+
+    merger = MergeInputs(None)
+    merged_local_shifts = merger.merge_all(data_path, seg_params, reg_params)
+
+    merged_localizations = (
+        data_path / seg_params.localize_3d_folder / "data" / "localizations_3D_barcode.dat"
+    )
+    merged_registration = (
+        data_path / reg_params.register_local_folder / "data" / "shifts_block3D.dat"
+    )
+
+    assert merged_localizations.exists()
+    assert merged_registration.exists()
+    assert merged_local_shifts == str(merged_registration)
+
+    stacked_localizations = Table.read(merged_localizations, format="ascii.ecsv")
+    stacked_registration = Table.read(merged_registration, format="ascii.ecsv")
+    assert len(stacked_localizations) == 2
+    assert len(stacked_registration) == 2
+
+
+def test_merge_inputs_skips_when_outputs_present(tmp_path):
+    data_path = tmp_path
+    seg_params = SimpleNamespace(
+        localize_2d_folder="localize_2d",
+        localize_3d_folder="localize_3d",
+        outputFile="localizations",
+    )
+    reg_params = SimpleNamespace(
+        register_local_folder="register_local", outputFile="shifts"
+    )
+
+    existing_localization = (
+        data_path / seg_params.localize_3d_folder / "data" / "localizations_3D_barcode.dat"
+    )
+    existing_localization.parent.mkdir(parents=True, exist_ok=True)
+    _write_dummy_table(existing_localization, 10)
+
+    existing_registration = (
+        data_path / reg_params.register_local_folder / "data" / "shifts_block3D.dat"
+    )
+    existing_registration.parent.mkdir(parents=True, exist_ok=True)
+    _write_dummy_table(existing_registration, 20)
+
+    merger = MergeInputs(None)
+    merged_local_shifts = merger.merge_all(data_path, seg_params, reg_params)
+
+    assert merged_local_shifts == str(existing_registration)
+    assert Table.read(existing_localization, format="ascii.ecsv")["ROI #"][0] == 10
+    assert Table.read(existing_registration, format="ascii.ecsv")["ROI #"][0] == 20


### PR DESCRIPTION
Main changes:

- add possibility to process single files for localize_3d and register_local to  enable paralelization in cines.
- output log files are now saved inside a directory not in the root folder. This is to enable nextflow pipelining that will need to check for changes in the root directory files and gets confused when new files are added during parallel runs
- add UID for log names for parallel executions
- added module to merge_inputs to handle parallel executions

This PR updates pyHiM to better support parallelized execution (e.g., in CINES / Nextflow) by enabling single-file processing, consolidating per-file outputs back into the single-file convention expected downstream, and isolating run artifacts into a dedicated logs/ directory to avoid root-folder churn.

Changes:

Add --inputFile support to restrict certain steps to a single image file and adjust output naming to avoid collisions in parallel runs.
Introduce merge_inputs to consolidate per-file localization/registration tables into the consolidated filenames required by downstream steps.
Move log outputs (and some derived artifacts) under root/logs/ and add UUIDs to log filenames; update archiving to include logs.
Reviewed changes
Copilot reviewed 19 out of 19 changed files in this pull request and generated 7 comments.

Show a summary per file
File	Description
tests/test_merge_inputs.py	Adds tests validating that per-file tables are merged into the expected consolidated outputs.
src/toolbox/file_handling/zipHiM_run.py	Updates tar collection to include files in logs/ (relative paths) as well as root.
src/pyHiM.py	Wires --inputFile through to relevant steps and adds a merge_inputs stage to the legacy pipeline.
src/matrixOperations/register_localizations.py	Switches registration input discovery to consolidated localization tables.
src/matrixOperations/merge_inputs.py	New module that merges per-file localization/registration ECSV tables into consolidated filenames.
src/matrixOperations/filter_localizations.py	Switches filtering input discovery to consolidated localization tables.
src/matrixOperations/build_traces.py	Switches trace building to use consolidated localization tables only.
src/imageProcessing/segmentSources3D.py	Adds single-file selection and per-file output naming; refactors Stardist model selection.
src/imageProcessing/segmentMasks3D.py	Adds single-file selection and label-aware Stardist default model selection.
src/imageProcessing/segmentMasks.py	Stops forcing CUDA_VISIBLE_DEVICES=1; updates GPU selection guidance in logs.
src/imageProcessing/alignImages3D.py	Adds single-file selection and per-file output naming for local registration shifts.
src/core/run_args.py	Adds --inputFile CLI argument and registers merge_inputs as an available command.
src/core/pyhim_logging.py	Writes logs/markdown to root/logs/ and adds a UUID to log filenames for parallel runs.
src/core/parameters.py	Updates mask-file selection logic to accept cycles like mask1 (but also adds debug logging).
src/core/function_caller.py	Adds merge_inputs command parsing and passes input_file into Pipeline/single-file routines.
src/core/data_manager.py	Determines a logs directory and stores parameters_loaded.json under it; makes folder creation idempotent.
environment.yml	Updates pinned versions and changes TensorFlow install spec.
docs/source/contributor/dev_installation.md	Adds GPU recognition and device selection instructions.
README.md	Adds a publication sentence (currently missing an actual link/citation).
