### PR TITLE
Refine register_global 3D z-shift polling: add sliceSize, enforce shape, and use (z,x,y) shifts

### DIFF
--- a/docs/source/reference/infoList_comprehension.md
+++ b/docs/source/reference/infoList_comprehension.md
@@ -51,6 +51,8 @@ Each section in `common` represents a step of pyHiM processing. Parameters are d
 |blockSize|Define size in (X,Y) of block for global XY block alignment|
 |globalAlignment|Select global registration output mode: `2D` (default) or `3D`|
 |sliceSize|Target width (in pixels) of X/Y slices used for Z-shift polling when `globalAlignment=3D`|
+|zMinSignalFraction|Minimum fraction of above-background pixels required for a slice to be used in Z-shift polling|
+|zMinSignalFractionAuto|If `True`, automatically relaxes `zMinSignalFraction` when no valid slices are found|
 |folder|Give a name of output folder to save output data of register_global features|
 |higher_threshold|Set higher threshold to adjust image intensity levels before xcorrelation for `alignment in 2D`|
 |localAlignment|Select mode between global alignment (`None`), 2D local alignment (`mask2D`) and 3D local alignment ( `block3D`)|

--- a/docs/source/reference/infoList_comprehension.md
+++ b/docs/source/reference/infoList_comprehension.md
@@ -48,7 +48,9 @@ Each section in `common` represents a step of pyHiM processing. Parameters are d
 |---|---|
 |alignByBlock|True will perform block alignment. False will do global alignment.|
 |background_sigma|Remove inhomogeneous background; set the number of standard deviations to use for both the lower and upper clipping limit ([astropy.stats.SigmaClip](https://docs.astropy.org/en/stable/api/astropy.stats.SigmaClip.html))|
-|blockSize|Define size in (X,Y) of block for 3D local alignment; value needs to be a power of 2|
+|blockSize|Define size in (X,Y) of block for global XY block alignment|
+|globalAlignment|Select global registration output mode: `2D` (default) or `3D`|
+|sliceSize|Target width (in pixels) of X/Y slices used for Z-shift polling when `globalAlignment=3D`|
 |folder|Give a name of output folder to save output data of register_global features|
 |higher_threshold|Set higher threshold to adjust image intensity levels before xcorrelation for `alignment in 2D`|
 |localAlignment|Select mode between global alignment (`None`), 2D local alignment (`mask2D`) and 3D local alignment ( `block3D`)|

--- a/docs/source/user_guide/modules/preprocessing/align_images.md
+++ b/docs/source/user_guide/modules/preprocessing/align_images.md
@@ -29,6 +29,8 @@ Parameters for this script will be read from the  ```register_global``` field of
 |alignByBlock| | Sets to false if a block correction is not needed. Default: True|
 |globalAlignment|`2D`, `3D`|Selects whether global registration stores XY-only (`2D`) or ZXY (`3D`) shifts. Default: `2D`.|
 |sliceSize|integer|Target slice width (in pixels) used for Z-shift polling in `3D` mode. Default: `200`.|
+|zMinSignalFraction|float|Minimum fraction of above-background pixels required for a slice to be considered in Z polling. Default: `0.01`.|
+|zMinSignalFractionAuto|bool|If `True`, pyHiM automatically relaxes `zMinSignalFraction` when no valid slices are found. Default: `True`.|
 
 
 ## Description
@@ -50,4 +52,4 @@ There are several ways to compute the shift:
 - Splits image in blocks and makes cross-correlation block by block. The `alignByBlock` parameter in the `alignImages` field of `parameters.json` should be set to `True`. It calculates the optimal shift between fiducial and reference in each block. It estimates the root mean squared error (RMS) between the reference and the shifted image for each block, and uses the blocks in which the RMS is within `tolerance`. Mean and standard deviation of the XY shifts are calculated, and mean shifts are used for shifting the image and getting the final RMS error. This method is more robust against a bright noise spot.
 
 
-When `globalAlignment` is set to `3D`, the pipeline first computes the robust XY shift exactly as before, then computes a global Z shift by polling per-slice Z estimates from X/Y slices that contain at least 20% above-background pixels in both reference and target stacks. The saved shift is ordered as `(z, x, y)` to match NumPy/scikit-image axis order `(z, y, x)` for 3D shift operations.
+When `globalAlignment` is set to `3D`, the pipeline first computes the robust XY shift exactly as before, then computes a global Z shift by polling per-slice Z estimates from X/Y slices that contain at least `zMinSignalFraction` above-background pixels in both reference and target stacks. The saved shift is ordered as `(z, x, y)` to match NumPy/scikit-image axis order `(z, y, x)` for 3D shift operations.

--- a/docs/source/user_guide/modules/preprocessing/align_images.md
+++ b/docs/source/user_guide/modules/preprocessing/align_images.md
@@ -12,12 +12,12 @@ pyhim -C register_global
 |Name shape|Quantity|Mandatory|Description|
 |---|---|---|---|
 |parameters.json|1|Yes|Parameter file.|
-|<image_name>.tif|2..n|Yes|2D images with a fiducial channel to align.|
+|<image_name>.tif|2..n|Yes|3D images with a fiducial channel to align. `register_global` now computes the required 2D projections internally.|
 
 ## Outputs
 |Name shape|Quantity|Description|
 |---|---|---|
-|register_global.ecsv|1|X, Y shift for each image|
+|register_global.ecsv|1|Global shift for each image (X,Y in `2D` mode; Z,X,Y in `3D` mode)|
 
 ## Relevant options
 
@@ -27,6 +27,8 @@ Parameters for this script will be read from the  ```register_global``` field of
 |:-:|:-:|:-:|
 |referenceFiducial| |Selects reference barcode image|
 |alignByBlock| | Sets to false if a block correction is not needed. Default: True|
+|globalAlignment|`2D`, `3D`|Selects whether global registration stores XY-only (`2D`) or ZXY (`3D`) shifts. Default: `2D`.|
+|sliceSize|integer|Target slice width (in pixels) used for Z-shift polling in `3D` mode. Default: `200`.|
 
 
 ## Description
@@ -46,3 +48,6 @@ The algorithm takes images one by one and aligns them with the reference.
 There are several ways to compute the shift:
 - Global alignment makes simple cross-correlation with two images
 - Splits image in blocks and makes cross-correlation block by block. The `alignByBlock` parameter in the `alignImages` field of `parameters.json` should be set to `True`. It calculates the optimal shift between fiducial and reference in each block. It estimates the root mean squared error (RMS) between the reference and the shifted image for each block, and uses the blocks in which the RMS is within `tolerance`. Mean and standard deviation of the XY shifts are calculated, and mean shifts are used for shifting the image and getting the final RMS error. This method is more robust against a bright noise spot.
+
+
+When `globalAlignment` is set to `3D`, the pipeline first computes the robust XY shift exactly as before, then computes a global Z shift by polling per-slice Z estimates from X/Y slices that contain at least 20% above-background pixels in both reference and target stacks. The saved shift is ordered as `(z, x, y)` to match NumPy/scikit-image axis order `(z, y, x)` for 3D shift operations.

--- a/src/core/data_manager.py
+++ b/src/core/data_manager.py
@@ -495,6 +495,10 @@ class DataManager:
             return self.__find_file_with_this_part(
                 required_ref["label_part"], required_ref["label"], self.npy_files
             )
+        if required_ref["data_type"] == "tif":
+            return self.__find_file_with_this_part(
+                required_ref["label_part"], required_ref["label"], self.tif_files
+            )
         else:
             raise ValueError
 

--- a/src/core/function_caller.py
+++ b/src/core/function_caller.py
@@ -250,7 +250,14 @@ class Pipeline:
             self._init_labelled_feature(Project, "projection")
             ordered_routines.append("project")
         if "register_global" in self.cmds:
-            self._init_labelled_feature(RegisterGlobal, "registration")
+            labelled_feature = {}
+            for label in self.m_data_m.get_processable_labels():
+                if "registration" in self.labelled_sections[label]:
+                    params = self.m_data_m.labelled_params[label]
+                    labelled_feature[label] = RegisterGlobal(
+                        params.registration, params.projection
+                    )
+            self.features.append(labelled_feature)
             self._init_labelled_feature(ApplyRegisterGlobal, "registration")
             ordered_routines.append("register_global")
         if "register_local" in self.cmds:

--- a/src/core/parameters.py
+++ b/src/core/parameters.py
@@ -480,6 +480,12 @@ class RegistrationParams:
     )  # used to remove inhom background
     blockSize: int = set_default("blockSize", 256)  # register_global
     sliceSize: int = set_default("sliceSize", 200)  # register_global z-shift polling
+    zMinSignalFraction: float = set_default(
+        "zMinSignalFraction", 0.01
+    )  # minimum fraction of above-background pixels for z-shift slice polling
+    zMinSignalFractionAuto: bool = set_default(
+        "zMinSignalFractionAuto", True
+    )  # automatically relax zMinSignalFraction if no valid slices are found
     blockSizeXY: int = set_default("blockSizeXY", 128)  # register_local
     upsample_factor: int = set_default("upsample_factor", 100)  # register_local
     unknown_params: CatchAll = field(default_factory=lambda: {})

--- a/src/core/parameters.py
+++ b/src/core/parameters.py
@@ -452,6 +452,7 @@ class RegistrationParams:
     )  # output folder
     outputFile: str = set_default("outputFile", "shifts")
     referenceFiducial: str = set_default("referenceFiducial", "RT27")
+    globalAlignment: str = set_default("globalAlignment", "2D")  # options: 2D, 3D
     localAlignment: str = set_default(
         "localAlignment", "block3D"
     )  # options: None, mask2D, block3D
@@ -478,6 +479,7 @@ class RegistrationParams:
         "background_sigma", 3.0
     )  # used to remove inhom background
     blockSize: int = set_default("blockSize", 256)  # register_global
+    sliceSize: int = set_default("sliceSize", 200)  # register_global z-shift polling
     blockSizeXY: int = set_default("blockSizeXY", 128)  # register_local
     upsample_factor: int = set_default("upsample_factor", 100)  # register_local
     unknown_params: CatchAll = field(default_factory=lambda: {})

--- a/src/imageProcessing/alignImages.py
+++ b/src/imageProcessing/alignImages.py
@@ -20,6 +20,7 @@ image cross correlation
 import glob
 import os
 import sys
+from typing import Optional
 
 import numpy as np
 from astropy.stats import SigmaClip
@@ -54,7 +55,7 @@ from imageProcessing.imageProcessing import (
     reassemble_3d_image,
     scatter_3d_image,
 )
-from imageProcessing.makeProjections import Feature
+from imageProcessing.makeProjections import Feature, Project
 
 
 def preprocess_2d_img(img, background_sigma):
@@ -64,22 +65,305 @@ def preprocess_2d_img(img, background_sigma):
     return remove_inhomogeneous_background(norm_img, background_sigma)
 
 
+def project_3d_image(img, projection_params: Optional[ProjectionParams]):
+    """Builds a 2D projection from a 3D image.
+
+    Parameters
+    ----------
+    img : np.ndarray
+        Input 3D image (z, y, x).
+    projection_params : ProjectionParams or None
+        Projection settings. If None, falls back to max projection.
+
+    Returns
+    -------
+    np.ndarray
+        The projected 2D image.
+    """
+    if projection_params is None:
+        return np.max(img, axis=0)
+
+    projector = Project(projection_params)
+    if projection_params.mode == "laplacian":
+        img_projected, _ = projector._projection_laplacian(img)
+        return img_projected
+
+    img_reduce = projector.precise_z_planes(img, projection_params.mode)
+    return projector.projection_2d(img_reduce)
+
+
+def estimate_background_threshold(img):
+    """Estimates a robust background threshold from image intensities.
+
+    Parameters
+    ----------
+    img : np.ndarray
+        Input image from which to estimate a background-like threshold.
+
+    Returns
+    -------
+    float
+        Intensity threshold above background based on median and MAD.
+    """
+    flattened = img[np.isfinite(img)]
+    if flattened.size == 0:
+        return 0
+    median = np.median(flattened)
+    mad = np.median(np.abs(flattened - median))
+    if mad == 0:
+        std = np.std(flattened)
+        return median + 2 * std
+    return median + 3 * 1.4826 * mad
+
+
+def slice_has_signal(img_slice, threshold, min_fraction):
+    """Checks whether a slice contains enough non-background signal.
+
+    Parameters
+    ----------
+    img_slice : np.ndarray
+        Slice volume to evaluate.
+    threshold : float
+        Background threshold.
+    min_fraction : float
+        Minimum fraction of pixels that must be above threshold.
+
+    Returns
+    -------
+    bool
+        True when the slice meets the minimum signal fraction.
+    """
+    if img_slice.size == 0:
+        return False
+    fraction = np.count_nonzero(img_slice > threshold) / img_slice.size
+    return fraction >= min_fraction
+
+
+def _split_axis_slices(axis_size, slice_size):
+    """Splits an axis into approximately equal slices.
+
+    Parameters
+    ----------
+    axis_size : int
+        Size of the axis to split.
+    slice_size : int
+        Target size for each slice.
+
+    Returns
+    -------
+    list[slice]
+        Slice objects partitioning the axis.
+    """
+    if slice_size <= 0:
+        return [slice(0, axis_size)]
+    number_slices = max(1, axis_size // slice_size)
+    number_slices = min(number_slices, axis_size)
+    indices = np.array_split(np.arange(axis_size), number_slices)
+    return [slice(idx[0], idx[-1] + 1) for idx in indices if idx.size > 0]
+
+
+def _filter_outlier_shifts(shifts):
+    """Removes outlier shifts with modified z-score based on MAD.
+
+    Parameters
+    ----------
+    shifts : list[float] | np.ndarray
+        Candidate shift estimates.
+
+    Returns
+    -------
+    np.ndarray
+        Filtered shift values.
+    """
+    if len(shifts) < 3:
+        return np.asarray(shifts)
+    shifts = np.asarray(shifts)
+    median = np.median(shifts)
+    mad = np.median(np.abs(shifts - median))
+    if mad == 0:
+        return shifts
+    modified_z_score = 0.6745 * (shifts - median) / mad
+    return shifts[np.abs(modified_z_score) <= 3.5]
+
+
+def _estimate_z_shift_from_axis_slices(
+    ref_img,
+    target_img,
+    axis,
+    slices,
+    ref_threshold,
+    target_threshold,
+    min_signal_fraction,
+    upsample_factor,
+):
+    """Estimates Z shifts from slices taken along one spatial axis.
+
+    Parameters
+    ----------
+    ref_img : np.ndarray
+        Reference 3D image in (z, y, x) order.
+    target_img : np.ndarray
+        Target 3D image in (z, y, x) order.
+    axis : int
+        Spatial axis used to define slices (1 for y, 2 for x).
+    slices : list[slice]
+        Slice intervals along the requested axis.
+    ref_threshold : float
+        Background threshold for reference image.
+    target_threshold : float
+        Background threshold for target image.
+    min_signal_fraction : float
+        Minimum fraction of signal pixels required to keep a slice.
+    upsample_factor : int
+        Subpixel upsampling factor for phase cross-correlation.
+
+    Returns
+    -------
+    list[float]
+        Candidate z-shifts measured for valid slices.
+    """
+    z_shifts = []
+    for current_slice in slices:
+        if axis == 2:
+            ref_slice = ref_img[:, :, current_slice]
+            target_slice = target_img[:, :, current_slice]
+            ref_proj = np.sum(ref_slice, axis=2)
+            target_proj = np.sum(target_slice, axis=2)
+        elif axis == 1:
+            ref_slice = ref_img[:, current_slice, :]
+            target_slice = target_img[:, current_slice, :]
+            ref_proj = np.sum(ref_slice, axis=1)
+            target_proj = np.sum(target_slice, axis=1)
+        else:
+            raise ValueError(f"Unsupported axis for z-shift slicing: {axis}")
+
+        if not (
+            slice_has_signal(ref_slice, ref_threshold, min_signal_fraction)
+            and slice_has_signal(target_slice, target_threshold, min_signal_fraction)
+        ):
+            continue
+
+        shift, _, _ = phase_cross_correlation(
+            ref_proj, target_proj, upsample_factor=upsample_factor
+        )
+        z_shifts.append(float(shift[0]))
+    return z_shifts
+
+
+def compute_global_z_shift_from_slices(
+    ref_img,
+    target_img,
+    slice_size,
+    min_signal_fraction=0.2,
+    upsample_factor=100,
+):
+    """Computes a robust global z-shift from x/y slice polling.
+
+    The function generates slices along x and y, keeps slices with enough
+    non-background signal in both reference and target, computes per-slice
+    z-shifts by phase correlation, removes outliers (MAD-based), and returns
+    the mean of the filtered estimates.
+
+    Parameters
+    ----------
+    ref_img : np.ndarray
+        Reference 3D image in (z, y, x) order.
+    target_img : np.ndarray
+        Target 3D image in (z, y, x) order (already xy-aligned).
+    slice_size : int
+        Target width for x/y slicing before z-shift polling.
+    min_signal_fraction : float, optional
+        Minimum fraction of above-background pixels to accept a slice.
+    upsample_factor : int, optional
+        Subpixel upsampling factor for phase correlation.
+
+    Returns
+    -------
+    tuple[float, int, int]
+        (global_z_shift, total_candidate_shifts, used_shifts_after_filter).
+    """
+    ref_threshold = estimate_background_threshold(ref_img)
+    target_threshold = estimate_background_threshold(target_img)
+
+    x_slices = _split_axis_slices(ref_img.shape[2], slice_size)
+    y_slices = _split_axis_slices(ref_img.shape[1], slice_size)
+
+    z_shifts = _estimate_z_shift_from_axis_slices(
+        ref_img,
+        target_img,
+        axis=2,
+        slices=x_slices,
+        ref_threshold=ref_threshold,
+        target_threshold=target_threshold,
+        min_signal_fraction=min_signal_fraction,
+        upsample_factor=upsample_factor,
+    )
+    z_shifts += _estimate_z_shift_from_axis_slices(
+        ref_img,
+        target_img,
+        axis=1,
+        slices=y_slices,
+        ref_threshold=ref_threshold,
+        target_threshold=target_threshold,
+        min_signal_fraction=min_signal_fraction,
+        upsample_factor=upsample_factor,
+    )
+
+    if not z_shifts:
+        print_log(
+            "$ No valid slices found for Z alignment; defaulting Z shift to 0.",
+            status="WARN",
+        )
+        return 0.0, 0, 0
+
+    filtered_shifts = _filter_outlier_shifts(z_shifts)
+    if len(filtered_shifts) == 0:
+        filtered_shifts = np.asarray(z_shifts)
+
+    return float(np.mean(filtered_shifts)), len(z_shifts), len(filtered_shifts)
+
+
 class RegisterGlobal(Feature):
-    def __init__(self, params: RegistrationParams):
+    def __init__(
+        self,
+        params: RegistrationParams,
+        projection_params: Optional[ProjectionParams] = None,
+    ):
         super().__init__(params)
-        self.npy_labels = ["fiducial"]
+        self.projection_params = projection_params
+        self.npy_labels = []
         self.required_ref = {
-            "data_type": "npy",
+            "data_type": "tif",
             "label_part": params.referenceFiducial,
             "label": "fiducial",
         }
+        self.tif_labels = ["fiducial"]
         self.out_folder = self.params.register_global_folder
         self.name = "RegisterGlobal"
 
-    def run(self, raw_2d_img, reference_2d_img):
-        if np.array_equal(raw_2d_img, reference_2d_img, equal_nan=True):
-            return [NpyFile(reference_2d_img, "_2d_registered")], None
+    def run(self, raw_3d_img, reference_3d_img):
+        """Computes global registration against the reference fiducial stack.
+
+        Parameters
+        ----------
+        raw_3d_img : np.ndarray
+            Target fiducial image stack in (z, y, x).
+        reference_3d_img : np.ndarray
+            Reference fiducial image stack in (z, y, x).
+
+        Returns
+        -------
+        tuple[list, dict]
+            Data files to save and metadata to merge in final outputs.
+        """
+        if raw_3d_img.shape != reference_3d_img.shape:
+            raise ValueError(
+                "Reference and target fiducial images must have identical shapes. "
+                f"Got target={raw_3d_img.shape}, reference={reference_3d_img.shape}."
+            )
         results_to_save = []
+        raw_2d_img = project_3d_image(raw_3d_img, self.projection_params)
+        reference_2d_img = project_3d_image(reference_3d_img, self.projection_params)
         preprocessed_img = preprocess_2d_img(raw_2d_img, self.params.background_sigma)
         preprocessed_ref = preprocess_2d_img(
             reference_2d_img, self.params.background_sigma
@@ -89,7 +373,7 @@ class RegisterGlobal(Feature):
             (
                 preprocessed_ref,
                 preprocessed_img,
-                shift,
+                shift_xy,
                 diffphase,
                 relative_shifts,
                 rms_image,
@@ -120,7 +404,27 @@ class RegisterGlobal(Feature):
                 EqualizationHistogramsFile(i_histogram, lower_threshold)
             )
 
-        shifted_img = shift_image(preprocessed_img, shift)
+        if not self.params.alignByBlock:
+            shift_xy = shift
+
+        shift = np.array([0.0, shift_xy[0], shift_xy[1]])
+        if self.params.globalAlignment == "3D":
+            target_xy_aligned = apply_xy_shift_3d_images(
+                raw_3d_img, shift_xy, parallel_execution=False
+            )
+            z_shift, total_slices, used_slices = compute_global_z_shift_from_slices(
+                reference_3d_img,
+                target_xy_aligned,
+                slice_size=self.params.sliceSize,
+                min_signal_fraction=0.2,
+                upsample_factor=100,
+            )
+            print_log(
+                f"$ Z-shift polling: {used_slices}/{total_slices} slices used."
+            )
+            shift = np.array([z_shift, shift_xy[0], shift_xy[1]])
+
+        shifted_img = shift_image(preprocessed_img, shift_xy)
         error = calcul_error(shifted_img, preprocessed_ref)
         # thresholds corrected images for better display and saves
         preprocessed_ref[preprocessed_ref < 0] = 0
@@ -136,28 +440,53 @@ class RegisterGlobal(Feature):
 
     def merge_results(self, results: list[dict]):
         dict_shift_roi = {}
-        alignment_results_table = Table(
-            names=(
-                "aligned file",
-                "reference file",
-                "shift_x",
-                "shift_y",
-                "error",
-                "diffphase",
-            ),
-            dtype=("S2", "S2", "f4", "f4", "f4", "f4"),
-        )
+        if self.params.globalAlignment == "3D":
+            alignment_results_table = Table(
+                names=(
+                    "aligned file",
+                    "reference file",
+                    "shift_z",
+                    "shift_x",
+                    "shift_y",
+                    "error",
+                    "diffphase",
+                ),
+                dtype=("S2", "S2", "f4", "f4", "f4", "f4", "f4"),
+            )
+        else:
+            alignment_results_table = Table(
+                names=(
+                    "aligned file",
+                    "reference file",
+                    "shift_x",
+                    "shift_y",
+                    "error",
+                    "diffphase",
+                ),
+                dtype=("S2", "S2", "f4", "f4", "f4", "f4"),
+            )
         for result_dict in results:
             label_part = result_dict["cycle"]
             shift = result_dict["shift"]
-            table_entry = [
-                result_dict["tif_name"],
-                result_dict["ref_tif_name"],
-                result_dict["shift"][0],
-                result_dict["shift"][1],
-                result_dict["error"],
-                result_dict["diffphase"],
-            ]
+            if self.params.globalAlignment == "3D" and len(shift) >= 3:
+                table_entry = [
+                    result_dict["tif_name"],
+                    result_dict["ref_tif_name"],
+                    shift[0],
+                    shift[1],
+                    shift[2],
+                    result_dict["error"],
+                    result_dict["diffphase"],
+                ]
+            else:
+                table_entry = [
+                    result_dict["tif_name"],
+                    result_dict["ref_tif_name"],
+                    shift[1] if len(shift) >= 3 else shift[0],
+                    shift[2] if len(shift) >= 3 else shift[1],
+                    result_dict["error"],
+                    result_dict["diffphase"],
+                ]
             dict_shift_roi[label_part] = shift.tolist()
             alignment_results_table.add_row(table_entry)
 
@@ -427,6 +756,8 @@ def apply_registrations_to_filename(
 
     if shift_array is not None:
         shift = np.asarray(shift_array)
+        if shift.size > 2:
+            shift = shift[1:3]
         # loads 2D image and applies registration
         im_obj = Image()
         im_obj.load_image_2d(
@@ -529,8 +860,11 @@ def apply_registrations_to_current_folder(
 
 
 def apply_xy_shift_3d_images(image, shift, parallel_execution=True):
-    """
-    Applies XY shift to a 3D stack
+    """Applies a rigid shift to 2D or 3D images.
+
+    For 3D images, accepted shift orders are:
+    - (y, x): interpreted as XY-only shift with z=0
+    - (z, y, x): interpreted as full 3D shift
 
     Parameters
     ----------
@@ -550,26 +884,43 @@ def apply_xy_shift_3d_images(image, shift, parallel_execution=True):
         if len(image.shape) == 2:
             output = shift_image(image, shift)
         elif len(image.shape) == 3:
-            shift_3d = np.zeros((3))
-            shift_3d[0], shift_3d[1], shift_3d[2] = 0, shift[0], shift[1]
+            shift_array = np.asarray(shift)
+            if shift_array.size == 2:
+                shift_3d = np.array([0, shift_array[0], shift_array[1]])
+            elif shift_array.size == 3:
+                shift_3d = shift_array
+            else:
+                raise ValueError(
+                    f"Shift for 3D image must have 2 or 3 values, got {shift_array.size}."
+                )
             output = shift_image(image, shift_3d)
         else:
             raise ValueError
     else:
-        print_log(
-            f"> Shifting {number_planes} planes using {len(client.scheduler_info()['workers'])} workers..."
-        )
+        shift_array = np.asarray(shift)
+        if len(image.shape) == 3 and shift_array.size == 3 and shift_array[0] != 0:
+            print_log(
+                "! Full 3D shifts with non-zero Z are applied in single-thread mode.",
+                status="WARN",
+            )
+            output = shift_image(image, shift_array)
+        else:
+            if len(image.shape) == 3 and shift_array.size == 3:
+                shift = shift_array[1:3]
+            print_log(
+                f"> Shifting {number_planes} planes using {len(client.scheduler_info()['workers'])} workers..."
+            )
 
-        image_list_scattered = scatter_3d_image(image)
+            image_list_scattered = scatter_3d_image(image)
 
-        futures = [
-            client.submit(shift_image, img, shift) for img in image_list_scattered
-        ]
+            futures = [
+                client.submit(shift_image, img, shift) for img in image_list_scattered
+            ]
 
-        output = reassemble_3d_image(client, futures, image.shape)
+            output = reassemble_3d_image(client, futures, image.shape)
 
-        del futures
-        del image_list_scattered
+            del futures
+            del image_list_scattered
 
     print_log("$ Done shifting 3D image.")
 

--- a/src/imageProcessing/alignImages.py
+++ b/src/imageProcessing/alignImages.py
@@ -513,6 +513,10 @@ class RegisterGlobal(Feature):
                 f"background thresholds ref/target={z_diag['ref_threshold']:.4g}/{z_diag['target_threshold']:.4g}."
             )
             shift = np.array([z_shift, shift_xy[0], shift_xy[1]])
+            print_log(
+                "$ Global 3D shift estimated (z, x, y): "
+                f"({shift[0]:.4f}, {shift[1]:.4f}, {shift[2]:.4f})"
+            )
 
         shifted_img = shift_image(preprocessed_img, shift_xy)
         error = calcul_error(shifted_img, preprocessed_ref)

--- a/src/imageProcessing/alignImages.py
+++ b/src/imageProcessing/alignImages.py
@@ -116,6 +116,26 @@ def estimate_background_threshold(img):
     return median + 3 * 1.4826 * mad
 
 
+def signal_fraction_above_threshold(img_slice, threshold):
+    """Computes the fraction of pixels above a threshold in a slice.
+
+    Parameters
+    ----------
+    img_slice : np.ndarray
+        Slice volume to evaluate.
+    threshold : float
+        Intensity threshold used to define signal pixels.
+
+    Returns
+    -------
+    float
+        Fraction of pixels above threshold.
+    """
+    if img_slice.size == 0:
+        return 0.0
+    return np.count_nonzero(img_slice > threshold) / img_slice.size
+
+
 def slice_has_signal(img_slice, threshold, min_fraction):
     """Checks whether a slice contains enough non-background signal.
 
@@ -130,13 +150,11 @@ def slice_has_signal(img_slice, threshold, min_fraction):
 
     Returns
     -------
-    bool
-        True when the slice meets the minimum signal fraction.
+    tuple[bool, float]
+        (is_valid, fraction_above_threshold).
     """
-    if img_slice.size == 0:
-        return False
-    fraction = np.count_nonzero(img_slice > threshold) / img_slice.size
-    return fraction >= min_fraction
+    fraction = signal_fraction_above_threshold(img_slice, threshold)
+    return fraction >= min_fraction, fraction
 
 
 def _split_axis_slices(axis_size, slice_size):
@@ -219,10 +237,14 @@ def _estimate_z_shift_from_axis_slices(
 
     Returns
     -------
-    list[float]
-        Candidate z-shifts measured for valid slices.
+    tuple[list[float], dict]
+        Candidate z-shifts and diagnostics for signal fractions/accepted slices.
     """
     z_shifts = []
+    ref_fractions = []
+    target_fractions = []
+    accepted_slices = 0
+
     for current_slice in slices:
         if axis == 2:
             ref_slice = ref_img[:, :, current_slice]
@@ -237,25 +259,45 @@ def _estimate_z_shift_from_axis_slices(
         else:
             raise ValueError(f"Unsupported axis for z-shift slicing: {axis}")
 
-        if not (
-            slice_has_signal(ref_slice, ref_threshold, min_signal_fraction)
-            and slice_has_signal(target_slice, target_threshold, min_signal_fraction)
-        ):
+        ref_ok, ref_fraction = slice_has_signal(
+            ref_slice, ref_threshold, min_signal_fraction
+        )
+        target_ok, target_fraction = slice_has_signal(
+            target_slice, target_threshold, min_signal_fraction
+        )
+        ref_fractions.append(ref_fraction)
+        target_fractions.append(target_fraction)
+
+        if not (ref_ok and target_ok):
             continue
 
+        accepted_slices += 1
         shift, _, _ = phase_cross_correlation(
             ref_proj, target_proj, upsample_factor=upsample_factor
         )
         z_shifts.append(float(shift[0]))
-    return z_shifts
+
+    diagnostics = {
+        "axis": axis,
+        "total_slices": len(slices),
+        "accepted_slices": accepted_slices,
+        "ref_fraction_min": float(np.min(ref_fractions)) if ref_fractions else 0.0,
+        "ref_fraction_median": float(np.median(ref_fractions)) if ref_fractions else 0.0,
+        "ref_fraction_max": float(np.max(ref_fractions)) if ref_fractions else 0.0,
+        "target_fraction_min": float(np.min(target_fractions)) if target_fractions else 0.0,
+        "target_fraction_median": float(np.median(target_fractions)) if target_fractions else 0.0,
+        "target_fraction_max": float(np.max(target_fractions)) if target_fractions else 0.0,
+    }
+    return z_shifts, diagnostics
 
 
 def compute_global_z_shift_from_slices(
     ref_img,
     target_img,
     slice_size,
-    min_signal_fraction=0.2,
+    min_signal_fraction=0.01,
     upsample_factor=100,
+    auto_relax=True,
 ):
     """Computes a robust global z-shift from x/y slice polling.
 
@@ -276,11 +318,13 @@ def compute_global_z_shift_from_slices(
         Minimum fraction of above-background pixels to accept a slice.
     upsample_factor : int, optional
         Subpixel upsampling factor for phase correlation.
+    auto_relax : bool, optional
+        If True, progressively relaxes min_signal_fraction when no valid slices exist.
 
     Returns
     -------
-    tuple[float, int, int]
-        (global_z_shift, total_candidate_shifts, used_shifts_after_filter).
+    tuple[float, int, int, dict]
+        (global_z_shift, total_candidate_shifts, used_shifts_after_filter, diagnostics).
     """
     ref_threshold = estimate_background_threshold(ref_img)
     target_threshold = estimate_background_threshold(target_img)
@@ -288,39 +332,80 @@ def compute_global_z_shift_from_slices(
     x_slices = _split_axis_slices(ref_img.shape[2], slice_size)
     y_slices = _split_axis_slices(ref_img.shape[1], slice_size)
 
-    z_shifts = _estimate_z_shift_from_axis_slices(
-        ref_img,
-        target_img,
-        axis=2,
-        slices=x_slices,
-        ref_threshold=ref_threshold,
-        target_threshold=target_threshold,
-        min_signal_fraction=min_signal_fraction,
-        upsample_factor=upsample_factor,
-    )
-    z_shifts += _estimate_z_shift_from_axis_slices(
-        ref_img,
-        target_img,
-        axis=1,
-        slices=y_slices,
-        ref_threshold=ref_threshold,
-        target_threshold=target_threshold,
-        min_signal_fraction=min_signal_fraction,
-        upsample_factor=upsample_factor,
-    )
+    fraction_schedule = [float(min_signal_fraction)]
+    if auto_relax:
+        fraction_schedule += [
+            max(0.001, min_signal_fraction / 2),
+            max(0.001, min_signal_fraction / 5),
+            0.001,
+        ]
+    # keep unique order
+    fraction_schedule = list(dict.fromkeys(fraction_schedule))
+
+    diagnostics = {
+        "ref_threshold": float(ref_threshold),
+        "target_threshold": float(target_threshold),
+        "x_total_slices": len(x_slices),
+        "y_total_slices": len(y_slices),
+        "attempts": [],
+    }
+
+    z_shifts = []
+    for candidate_fraction in fraction_schedule:
+        x_shifts, x_diag = _estimate_z_shift_from_axis_slices(
+            ref_img,
+            target_img,
+            axis=2,
+            slices=x_slices,
+            ref_threshold=ref_threshold,
+            target_threshold=target_threshold,
+            min_signal_fraction=candidate_fraction,
+            upsample_factor=upsample_factor,
+        )
+        y_shifts, y_diag = _estimate_z_shift_from_axis_slices(
+            ref_img,
+            target_img,
+            axis=1,
+            slices=y_slices,
+            ref_threshold=ref_threshold,
+            target_threshold=target_threshold,
+            min_signal_fraction=candidate_fraction,
+            upsample_factor=upsample_factor,
+        )
+        z_shifts = x_shifts + y_shifts
+        diagnostics["attempts"].append(
+            {
+                "min_signal_fraction": float(candidate_fraction),
+                "accepted_x": x_diag["accepted_slices"],
+                "accepted_y": y_diag["accepted_slices"],
+                "x_ref_fraction_median": x_diag["ref_fraction_median"],
+                "x_target_fraction_median": x_diag["target_fraction_median"],
+                "y_ref_fraction_median": y_diag["ref_fraction_median"],
+                "y_target_fraction_median": y_diag["target_fraction_median"],
+            }
+        )
+        if z_shifts:
+            diagnostics["selected_min_signal_fraction"] = float(candidate_fraction)
+            break
 
     if not z_shifts:
+        diagnostics["selected_min_signal_fraction"] = float(fraction_schedule[-1])
         print_log(
-            "$ No valid slices found for Z alignment; defaulting Z shift to 0.",
+            "$ No valid slices found for Z alignment; defaulting Z shift to 0. "
+            f"Thresholds ref/target={ref_threshold:.4g}/{target_threshold:.4g}; "
+            f"slice fractions medians (last try) x={diagnostics['attempts'][-1]['x_ref_fraction_median']:.4f}/"
+            f"{diagnostics['attempts'][-1]['x_target_fraction_median']:.4f}, "
+            f"y={diagnostics['attempts'][-1]['y_ref_fraction_median']:.4f}/"
+            f"{diagnostics['attempts'][-1]['y_target_fraction_median']:.4f}.",
             status="WARN",
         )
-        return 0.0, 0, 0
+        return 0.0, 0, 0, diagnostics
 
     filtered_shifts = _filter_outlier_shifts(z_shifts)
     if len(filtered_shifts) == 0:
         filtered_shifts = np.asarray(z_shifts)
 
-    return float(np.mean(filtered_shifts)), len(z_shifts), len(filtered_shifts)
+    return float(np.mean(filtered_shifts)), len(z_shifts), len(filtered_shifts), diagnostics
 
 
 class RegisterGlobal(Feature):
@@ -412,15 +497,20 @@ class RegisterGlobal(Feature):
             target_xy_aligned = apply_xy_shift_3d_images(
                 raw_3d_img, shift_xy, parallel_execution=False
             )
-            z_shift, total_slices, used_slices = compute_global_z_shift_from_slices(
+            z_shift, total_slices, used_slices, z_diag = compute_global_z_shift_from_slices(
                 reference_3d_img,
                 target_xy_aligned,
                 slice_size=self.params.sliceSize,
-                min_signal_fraction=0.2,
+                min_signal_fraction=self.params.zMinSignalFraction,
                 upsample_factor=100,
+                auto_relax=self.params.zMinSignalFractionAuto,
             )
+            selected_fraction = z_diag.get("selected_min_signal_fraction", self.params.zMinSignalFraction)
             print_log(
-                f"$ Z-shift polling: {used_slices}/{total_slices} slices used."
+                "$ Z-shift polling: "
+                f"{used_slices}/{total_slices} valid slices after outlier filtering; "
+                f"minSignalFraction used={selected_fraction:.4f}; "
+                f"background thresholds ref/target={z_diag['ref_threshold']:.4g}/{z_diag['target_threshold']:.4g}."
             )
             shift = np.array([z_shift, shift_xy[0], shift_xy[1]])
 

--- a/src/imageProcessing/segmentMasks3D.py
+++ b/src/imageProcessing/segmentMasks3D.py
@@ -123,7 +123,15 @@ class Mask3D:
             print_log("> Applying existing XY shift...")
             # applies XY shift to 3D stack
             if label != reference_fiducial:
-                print_log(f"$ Applies shift = [{shift[0]:.2f} ,{shift[1]:.2f}]")
+                shift_arr = np.asarray(shift)
+                if shift_arr.size >= 3:
+                    print_log(
+                        f"$ Applies shift (z,x,y) = [{shift_arr[0]:.2f}, {shift_arr[1]:.2f}, {shift_arr[2]:.2f}]"
+                    )
+                else:
+                    print_log(
+                        f"$ Applies shift (x,y) = [{shift_arr[0]:.2f}, {shift_arr[1]:.2f}]"
+                    )
                 image_3d = apply_xy_shift_3d_images(
                     image_3d, shift, parallel_execution=self.inner_parallel_loop
                 )
@@ -471,7 +479,14 @@ class Mask3D:
 
         # applies XY shift to 3D stack
         if label != reference_fiducial:
-            print_log(f"$ Applies shift = [{shift[0]:.2f} ,{shift[1]:.2f}]")
+            
+            shift_arr = np.asarray(shift)
+            if shift_arr.size >= 3:
+                print_log(
+                    f"$ Applies shift (z,x,y) = [{shift_arr[0]:.2f}, {shift_arr[1]:.2f}, {shift_arr[2]:.2f}]"
+                )
+            else:
+                print_log(f"$ Applies shift (x,y) = [{shift_arr[0]:.2f}, {shift_arr[1]:.2f}]")
             image_3d_aligned = apply_xy_shift_3d_images(
                 image_3d, shift, parallel_execution=self.inner_parallel_loop
             )

--- a/src/imageProcessing/segmentSources3D.py
+++ b/src/imageProcessing/segmentSources3D.py
@@ -264,7 +264,14 @@ class Localize3D:
 
         # applies XY shift to 3D stack
         if label != p["referenceBarcode"]:
-            print_log(f"$ Applies shift = [{shift[0]:.2f} ,{shift[1]:.2f}]")
+            
+            shift_arr = np.asarray(shift)
+            if shift_arr.size >= 3:
+                print_log(
+                    f"$ Applies shift (z,x,y) = [{shift_arr[0]:.2f}, {shift_arr[1]:.2f}, {shift_arr[2]:.2f}]"
+                )
+            else:
+                print_log(f"$ Applies shift (x,y) = [{shift_arr[0]:.2f}, {shift_arr[1]:.2f}]")
             image_3d_aligned = apply_xy_shift_3d_images(
                 image_3d, shift, parallel_execution=self.inner_parallel_loop
             )

--- a/src/toolbox/parameter_file/info_parameters.py
+++ b/src/toolbox/parameter_file/info_parameters.py
@@ -16,6 +16,8 @@ help_dic = {
     partitioned for the local drift correction\n\nDefault Value = 256",
     "referenceFiducial": "Define the name of the reference fiducial cycle which corresponds to the first cycle \
     acquired during the experience\n\nDefault Value = RT1",
+    "globalAlignment": "Select whether register_global stores XY-only (2D) or ZXY (3D) global shifts\n\nDefault Value = 2D",
+    "sliceSize": "Define the target width of X/Y slices used to estimate Z-shift by polling in register_global\n\nDefault Value = 200",
     "flux_min": "Set minimum flux per spot for 2D. If the flux is smaller than the threshold the localization will be \
     discarded\n\nDefault Value = 10",
     "flux_min_3D": "Set minimum flux per spot for 3D. If the flux is smaller than the threshold the localization will \

--- a/src/toolbox/parameter_file/info_parameters.py
+++ b/src/toolbox/parameter_file/info_parameters.py
@@ -18,6 +18,8 @@ help_dic = {
     acquired during the experience\n\nDefault Value = RT1",
     "globalAlignment": "Select whether register_global stores XY-only (2D) or ZXY (3D) global shifts\n\nDefault Value = 2D",
     "sliceSize": "Define the target width of X/Y slices used to estimate Z-shift by polling in register_global\n\nDefault Value = 200",
+    "zMinSignalFraction": "Minimum fraction of pixels above background required for a slice to be used in Z-shift polling\n\nDefault Value = 0.01",
+    "zMinSignalFractionAuto": "If True, automatically relaxes zMinSignalFraction when no valid slices are found\n\nDefault Value = True",
     "flux_min": "Set minimum flux per spot for 2D. If the flux is smaller than the threshold the localization will be \
     discarded\n\nDefault Value = 10",
     "flux_min_3D": "Set minimum flux per spot for 3D. If the flux is smaller than the threshold the localization will \

--- a/src/toolbox/parameter_file/parameters.json
+++ b/src/toolbox/parameter_file/parameters.json
@@ -20,6 +20,7 @@
             "background_sigma": 3.0,
             "blockSize": 128,
             "blockSizeXY": 128,
+            "globalAlignment": "2D",
             "higher_threshold": 0.9999999,
             "localAlignment": "block3D",
             "lower_threshold": 0.999,
@@ -27,6 +28,7 @@
             "referenceFiducial": "RT26",
             "register_global_folder": "register_global",
             "register_local_folder": "register_local",
+            "sliceSize": 200,
             "tolerance": 0.1,
             "upsample_factor": 100
         },

--- a/src/toolbox/parameter_file/parameters.json
+++ b/src/toolbox/parameter_file/parameters.json
@@ -29,6 +29,8 @@
             "register_global_folder": "register_global",
             "register_local_folder": "register_local",
             "sliceSize": 200,
+            "zMinSignalFraction": 0.01,
+            "zMinSignalFractionAuto": true,
             "tolerance": 0.1,
             "upsample_factor": 100
         },


### PR DESCRIPTION
### Motivation
- Introduce a dedicated parameter to control the X/Y slice width used when polling for Z-shifts instead of reusing `blockSize` so Z polling is tunable and decoupled from block alignment behavior. 
- Avoid surprising fallback behavior where equal 3D arrays were short-circuited into emitting an NPY projection; require identical stack shapes or fail early. 
- Ensure stored shifts match NumPy / scikit-image axis ordering to avoid incorrect Z application when other modules apply recorded shifts. 
- Clean up duplicated slice-polling loops and provide clear docstrings for new helper utilities.

### Description
- Added `sliceSize` parameter to `RegistrationParams` (default `200`) and to `parameters.json` and parameter docs so Z-polling uses a dedicated slice width (`src/core/parameters.py`, `src/toolbox/parameter_file/parameters.json`, `src/toolbox/parameter_file/info_parameters.py`).
- Reworked `RegisterGlobal.run` to accept 3D tif stacks, enforce identical target/reference shapes (raise `ValueError` if different), generate 2D projections internally, and compute a robust global Z shift only when `globalAlignment == "3D"` (`src/imageProcessing/alignImages.py`).
- Polling for Z now uses a refactored helper `_estimate_z_shift_from_axis_slices` and `_split_axis_slices`/`slice_has_signal`/`_filter_outlier_shifts` utilities; these include docstrings and use MAD/modified z-score to reject outlier per-slice estimates before averaging (`src/imageProcessing/alignImages.py`).
- Store saved 3D global shifts as `(z, x, y)` and 2D-only shifts as `(0, x, y)` so downstream code applying shifts matches ndarray axis order; updated `merge_results`, apply/save logic and consumer logging to reflect zxy format (`src/imageProcessing/alignImages.py`, `src/imageProcessing/segmentMasks3D.py`, `src/imageProcessing/segmentSources3D.py`).
- Hardened `apply_xy_shift_3d_images` to accept both 2-value `(x,y)` and 3-value `(z,x,y)` shift inputs and handle parallel/single-thread cases safely; added explanatory docstring (`src/imageProcessing/alignImages.py`).
- Updated `DataManager.load_reference` to resolve TIFF references so `RegisterGlobal` can request full 3D tif references (`src/core/data_manager.py`).
- Updated user documentation and parameter reference to describe `globalAlignment`, `sliceSize`, and the new 3D behavior and shift ordering (`docs/source/user_guide/modules/preprocessing/align_images.md`, `docs/source/reference/infoList_comprehension.md`).

### Testing
- Performed static/compile-time checks with `python -m compileall` on modified modules: `src/imageProcessing/alignImages.py`, `src/imageProcessing/segmentSources3D.py`, `src/imageProcessing/segmentMasks3D.py`, `src/core/parameters.py`, `src/core/function_caller.py`, `src/core/data_manager.py`, and updated docs files; compilation completed successfully. 
- Grepped for affected symbols (`sliceSize`, shift usage, logging lines) to ensure consumers were updated; no runtime unit tests were added or run beyond the compile checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6989f2fe67c48330a8942a0cd7f8b4e8)