### PR TITLE
Fix missing imports in alignImages shift-plot path

### DIFF
--- a/src/imageProcessing/alignImages.py
+++ b/src/imageProcessing/alignImages.py
@@ -17,10 +17,14 @@ image cross correlation
 # IMPORTS
 # =============================================================================
 
+import glob
+import os
+import re
 import sys
 
 import numpy as np
 import matplotlib.pyplot as plt
+import pandas as pd
 from astropy.stats import SigmaClip
 from astropy.table import Table
 from numpy import linalg as LA


### PR DESCRIPTION
### Motivation
- The recent addition of a global-shifts plotting path referenced standard-library modules and `pandas` that were not imported, causing undefined-name errors when applying registrations and generating plots.
- Restoring the missing imports ensures the new plotting and registration-application code paths can execute without NameError failures.

### Description
- Added the missing standard-library imports `glob`, `os`, and `re` at the top of `src/imageProcessing/alignImages.py` to support file path handling and regex operations.
- Added the `pandas` import as `pd` to support `prepare_table_from_json` which builds a `DataFrame` for plotting.
- The change unblocks the existing `apply_registrations_to_current_folder()` integration with `prepare_table_from_json()` and `generate_shift_plot()` so that `Shifts_barplot.png` can be generated.
- Only `src/imageProcessing/alignImages.py` was modified to restore these imports.

### Testing
- Ran `ruff check src/imageProcessing/alignImages.py` and it passed successfully.
- Ran `python -m compileall -q src/imageProcessing/alignImages.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69df917cc0188330bcdc38f61a19c4a5)