### PR TITLE
patched spelling in doc

### DIFF
--- a/docs/source/user_guide/modules/identification/segment_masks_3d.md
+++ b/docs/source/user_guide/modules/identification/segment_masks_3d.md
@@ -26,12 +26,12 @@ A 3D mask segmentation produces two outputs saved in the `segmentedObjects` fo
 
 ```
 scan_002_mask0_002_ROI_converted_decon_ch01.tif_3Dmasks.png
-scan_002_mask0_002_ROI_converted_decon_ch01._3Dmasks.npy
+scan_002_mask0_002_ROI_converted_decon_ch01_3Dmasks.npy
 ```
 
 The PNG file is a representation of the raw image and the segmented objects.
 
-The NPY file is a 3D labeled numpy array containing the segmented objects. The file name is constructed using the original root filename with the tag `_3DMasks`.
+The NPY file is a 3D labeled numpy array containing the segmented objects. The file name is constructed using the original root filename with the tag `_3Dmasks`.
 
 _Warning_: This mode operates in 3D, therefore the Startdist network provided **must be** in 3D.
 

--- a/src/imageProcessing/segmentMasks3D.py
+++ b/src/imageProcessing/segmentMasks3D.py
@@ -480,7 +480,7 @@ class Mask3D:
 
         if number_masks > 0:
 
-            original_filename_root = os.path.basename(filename_to_process).split("_unregistered.npy")[0]
+            original_filename_root = os.path.basename(filename_to_process).split("_3Dmasks_unregistered.npy")[0]
 
             npy_labeled_image_shifted = (
                 data_path
@@ -490,6 +490,7 @@ class Mask3D:
                 + "data"
                 + os.sep
                 + original_filename_root
+                + "_3Dmasks"
                 + ".npy"
             )
 


### PR DESCRIPTION
It is unclear how masks that were segmented externally can be read by pyHiM and registered. We fixed a number of filename issues to make sure this now works.

The previous version did not enforce the filename with masks to abide by this naming format '_3Dmasks_unregistered.npy'.

This new version only works if this is respected.


