### PR TITLE
docs: add BED file guidance for build_traces chromatin trace docs

### DIFF
--- a/docs/source/user_guide/modules/building_traces.md
+++ b/docs/source/user_guide/modules/building_traces.md
@@ -15,6 +15,8 @@ Two methods are used for pre-processing localization tables.
 
 The main method for building chromatin traces is `build_traces`.
 
+`build_traces` also supports optional BED-driven barcode/genomic annotation through the `barcode_coordinates_BEDfile` parameter in `buildsPWDmatrix` (see the detailed `build_traces` page below).
+
 Chromatin trace tables can be post-processed using multiple scripts:
 
 - `trace_analyser`: quantifies several quantities from a trace table.

--- a/docs/source/user_guide/modules/building_traces/build_traces.md
+++ b/docs/source/user_guide/modules/building_traces/build_traces.md
@@ -29,7 +29,50 @@ Parameters to run this script will be read from the ```buildsPWDmatrix``` field 
 "mask_expansion": 8,# number of pixels masks will be expanded to assign localizations
 "masks2process":{"nuclei":"DAPI","mask1":"mask0"}, # masks identities to process
 "KDtree_distance_threshold_mum": 1, # threshold distance used for KDtree clustering
+"barcode_coordinates_BEDfile": "", # optional BED file used to annotate barcodes with genomic coordinates
 ```
+
+### Optional BED-driven barcode annotation
+
+If `barcode_coordinates_BEDfile` is set to a valid BED file path, `build_traces` will load that file and use it to enrich each saved trace entry with genomic metadata.
+
+Example in `parameters.json` (`buildsPWDmatrix` section):
+
+```json
+"buildsPWDmatrix": {
+  "tracing_method": ["masking", "clustering"],
+  "mask_expansion": 8,
+  "masks2process": {"nuclei": "DAPI"},
+  "KDtree_distance_threshold_mum": 1,
+  "barcode_coordinates_BEDfile": "resources/barcode_coordinates.bed"
+}
+```
+
+When a BED file is provided:
+
+- Barcode identities are validated against the BED mapping.
+- If a 5th BED column is present, barcode IDs can be remapped before writing the trace table.
+- `Chrom`, `Chrom_Start`, and `Chrom_End` columns in the output trace table are populated from BED coordinates.
+
+### BED file format expected by `build_traces`
+
+Use a tab-separated BED-like file (no header), with at least 4 columns:
+
+1. `chrom` (e.g. `chr2L`, `chrX`)
+2. `start` (genomic start, basepairs)
+3. `end` (genomic end, basepairs)
+4. `barcode` (barcode ID expected in localizations)
+5. *(optional)* `barcode_remap` (barcode ID written to output table after remapping)
+
+Example:
+
+```text
+chr2L	150000	151000	1
+chr2L	220000	221000	2	102
+chr2L	300000	301000	3
+```
+
+In this example, barcode `2` is remapped to `102` when traces are saved, while all entries receive genomic coordinates from columns 1 to 3.
 
 Output images:
 


### PR DESCRIPTION
### Motivation

- Make users aware of the new optional BED-driven barcode mapping supported by `build_traces` and document how to enable it from the `buildsPWDmatrix` section of `parameters.json`.
- Provide a clear description of the expected BED format and the runtime effects (validation, optional remapping, and genomic fields population) so users can prepare compatible files.

### Description

- Added a short note on the "Building chromatin traces" landing page pointing to the `build_traces` BED workflow in `docs/source/user_guide/modules/building_traces.md`.
- Extended the `build_traces` page (`docs/source/user_guide/modules/building_traces/build_traces.md`) to include the `"barcode_coordinates_BEDfile"` parameter in the `buildsPWDmatrix` snippet and a new section `Optional BED-driven barcode annotation` describing behavior when a BED file is provided.
- Documented the expected BED-like file format (tab-separated, no header) with required columns `chrom`, `start`, `end`, `barcode` and an optional fifth column `barcode_remap`, and provided a short example showing remapping behavior.
- This is a documentation-only change (no runtime code modified); changed files: `docs/source/user_guide/modules/building_traces.md` and `docs/source/user_guide/modules/building_traces/build_traces.md`.

### Testing

- Ran `git diff --check` to validate no whitespace/patch issues and the check passed.
- Verified working tree status with `git -C /workspace/pyHiM status --short` to confirm the intended files were modified.
- Committed the documentation changes with a descriptive commit message, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e0886c3028833080b8c0800c54eb1a)