### PR TITLE
Add direct 3D shift application for 3D mask registration

### DIFF
--- a/src/imageProcessing/alignImages.py
+++ b/src/imageProcessing/alignImages.py
@@ -1030,6 +1030,43 @@ def apply_xy_shift_3d_images(image, shift, parallel_execution=True):
     return output
 
 
+def apply_shift_3d_images(image, shift):
+    """Applies a rigid shift to a 3D image in one interpolation call.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input 3D image in (z, x, y) axis order.
+    shift : array-like
+        Shift values as either (x, y) or (z, x, y).
+        If only 2 values are provided, z-shift defaults to 0.
+
+    Returns
+    -------
+    np.ndarray
+        Shifted 3D image.
+    """
+    if image.ndim != 3:
+        raise ValueError(f"Expected a 3D image, got ndim={image.ndim}.")
+
+    shift_array = np.asarray(shift, dtype=float).flatten()
+    if shift_array.size == 2:
+        shift_3d = np.array([0.0, shift_array[0], shift_array[1]])
+    elif shift_array.size == 3:
+        shift_3d = shift_array
+    else:
+        raise ValueError(
+            f"Shift for 3D image must have 2 or 3 values, got {shift_array.size}."
+        )
+
+    print_log(
+        f"> Applying direct 3D shift with scipy.ndimage.shift: [{shift_3d[0]:.2f}, {shift_3d[1]:.2f}, {shift_3d[2]:.2f}]"
+    )
+    output = shift_image(image, shift_3d)
+    print_log("$ Done shifting 3D image.")
+    return output
+
+
 def image_block_alignment_3d(images, block_size_xy=256, upsample_factor=100):
     # sanity checks
     if len(images) < 2:

--- a/src/imageProcessing/segmentMasks3D.py
+++ b/src/imageProcessing/segmentMasks3D.py
@@ -27,7 +27,7 @@ from core.data_manager import create_folder
 from core.parameters import AcquisitionParams, SegmentationParams, load_alignment_dict
 from core.pyhim_logging import print_log, print_session_name, write_string_to_file
 from core.saving import plot_raw_images_and_labels
-from imageProcessing.alignImages import apply_xy_shift_3d_images
+from imageProcessing.alignImages import apply_shift_3d_images
 from imageProcessing.makeProjections import reinterpolate_z
 from imageProcessing.segmentMasks import _segment_3d_masks
 
@@ -132,9 +132,7 @@ class Mask3D:
                     print_log(
                         f"$ Applies shift (x,y) = [{shift_arr[0]:.2f}, {shift_arr[1]:.2f}]"
                     )
-                image_3d = apply_xy_shift_3d_images(
-                    image_3d, shift, parallel_execution=self.inner_parallel_loop
-                )
+                image_3d = apply_shift_3d_images(image_3d, shift)
             else:
                 print_log("$ Running reference fiducial cycle: no shift applied!")
         else:
@@ -468,9 +466,7 @@ class Mask3D:
                 )
             else:
                 print_log(f"$ Applies shift (x,y) = [{shift_arr[0]:.2f}, {shift_arr[1]:.2f}]")
-            image_3d_aligned = apply_xy_shift_3d_images(
-                image_3d, shift, parallel_execution=self.inner_parallel_loop
-            )
+            image_3d_aligned = apply_shift_3d_images(image_3d, shift)
         else:
             print_log("$ Running reference fiducial cycle: no shift applied!")
             shift = np.array([0, 0])

--- a/tests/test_apply_shift_3d_images.py
+++ b/tests/test_apply_shift_3d_images.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import numpy as np
+from scipy.ndimage import shift as shift_image
+
+from imageProcessing.alignImages import apply_shift_3d_images
+
+
+def test_apply_shift_3d_images_from_xy_shift():
+    image = np.zeros((5, 7, 9), dtype=float)
+    image[2, 3, 4] = 1.0
+
+    shifted = apply_shift_3d_images(image, [1, -2])
+    expected = shift_image(image, [0, 1, -2])
+
+    assert np.allclose(shifted, expected)
+
+
+def test_apply_shift_3d_images_from_zxy_shift():
+    image = np.zeros((5, 7, 9), dtype=float)
+    image[2, 3, 4] = 1.0
+
+    shifted = apply_shift_3d_images(image, [1, -2, 3])
+    expected = shift_image(image, [1, -2, 3])
+
+    assert np.allclose(shifted, expected)


### PR DESCRIPTION
### Motivation
- Existing registration paths applied shifts per-plane or treated 3D shifts specially, which prevented applying a full 3D interpolation in a single call when a 3D shift vector is available.
- A single-call 3D shift via `scipy.ndimage.shift` is simpler and avoids sequential per-plane interpolation artifacts or unnecessary complexity.

### Description
- Added `apply_shift_3d_images` in `src/imageProcessing/alignImages.py` which accepts a shift as `[x, y]` or `[z, x, y]`, normalizes 2-value shifts to 3D by prepending `z=0`, and applies the shift with a single `scipy.ndimage.shift` call, raising on invalid inputs.
- Replaced uses of `apply_xy_shift_3d_images` with `apply_shift_3d_images` in `src/imageProcessing/segmentMasks3D.py` so 3D mask files are registered with the new direct-3D-shift behavior.
- Added unit tests in `tests/test_apply_shift_3d_images.py` that validate both XY-only (`[x,y]`) and ZXY (`[z,x,y]`) inputs produce the same result as `scipy.ndimage.shift`.

### Testing
- Ran `pytest -q tests/test_apply_shift_3d_images.py` which attempted to collect and run the new tests but failed during collection due to the environment missing `numpy` (`ModuleNotFoundError: No module named 'numpy'`).
- The tests exercise that `apply_shift_3d_images` matches `scipy.ndimage.shift` for both 2-value and 3-value shift inputs, but full execution could not be completed in this environment due to the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb74ef47b48330af137fab162f3f4f)