### PR TITLE
Use RGB overlays in RefDiffFile comparison panels

### DIFF
--- a/src/core/data_file.py
+++ b/src/core/data_file.py
@@ -324,16 +324,18 @@ class RefDiffFile(DataFile):
             img_4, lower_threshold=0.5, higher_threshold=0.9999
         )
 
-        cmap = "seismic"
-
         fig, (ax1, ax2) = plt.subplots(1, 2)
         fig.set_size_inches((60, 30))
 
-        ax1.imshow(img_1 - img_2, cmap=cmap)
+        null_image = np.zeros(self.preprocessed_ref.shape)
+        rgb_uncorrected = np.dstack([img_1, img_2, null_image])
+        rgb_corrected = np.dstack([img_3, img_4, null_image])
+
+        ax1.imshow(rgb_uncorrected)
         ax1.axis("off")
         ax1.set_title("uncorrected")
 
-        ax2.imshow(img_3 - img_4, cmap=cmap)
+        ax2.imshow(rgb_corrected)
         ax2.axis("off")
         ax2.set_title("corrected")
 


### PR DESCRIPTION
### Motivation
- Improve readability of the reference vs original/shifted comparisons by showing both panels as RGB overlays (matching `BothImgRbgFile`) instead of difference heatmaps.

### Description
- Update `RefDiffFile.save` in `src/core/data_file.py` to normalize and `image_adjust` inputs as before, create a zero third channel with `null_image = np.zeros(self.preprocessed_ref.shape)`, stack channels with `np.dstack` into `rgb_uncorrected` and `rgb_corrected`, and display these RGB overlays in the two subplots using `ax.imshow`, preserving the existing preprocessing flow.

### Testing
- Ran `pytest -q tests/test_register_global.py -k global` which failed during collection due to `ModuleNotFoundError: No module named 'core'`.
- Ran `PYTHONPATH=src pytest -q tests/test_register_global.py -k global` which failed because `matplotlib` is not installed in the environment, so no automated tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0ffef693608330b99e4101cbd7f4b8)