### PR TITLE
docs: correct register_global output file documentation

### DIFF
--- a/docs/source/user_guide/modules/preprocessing/align_images.md
+++ b/docs/source/user_guide/modules/preprocessing/align_images.md
@@ -17,7 +17,8 @@ pyhim -C register_global
 ## Outputs
 |Name shape|Quantity|Description|
 |---|---|---|
-|register_global.ecsv|1|Global shift for each image (X,Y in `2D` mode; Z,X,Y in `3D` mode)|
+|shifts.table|1|Text table containing the global shift dictionary for each image (X,Y in `2D` mode; Z,X,Y in `3D` mode).|
+|shifts.json|1|JSON file containing the global shift dictionary for each image (X,Y in `2D` mode; Z,X,Y in `3D` mode).|
 
 ## Relevant options
 


### PR DESCRIPTION
### Motivation
- The `register_global` documentation incorrectly listed `register_global.ecsv` as the output while the script actually writes `shifts.table` and `shifts.json`.

### Description
- Updated `docs/source/user_guide/modules/preprocessing/align_images.md` to replace `register_global.ecsv` with `shifts.table` (text table of the global shift dictionary) and `shifts.json` (JSON of the global shift dictionary), and clarified the XY (`2D`) / ZXY (`3D`) formats.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1003d2c9a4833099588c9c6e08ebc8)