### PR TITLE
Update register_global reference-difference plot titles and remove redundant overlay export

### DIFF
--- a/src/core/data_file.py
+++ b/src/core/data_file.py
@@ -8,6 +8,7 @@ Manage files operations, depending of DataManager.
 
 import json
 import os
+import re
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -277,12 +278,21 @@ class BothImgRbgFile(DataFile):
 
 
 class RefDiffFile(DataFile):
-    def __init__(self, preprocessed_ref, shifted_img, preprocessed_img):
+    def __init__(
+        self,
+        preprocessed_ref,
+        shifted_img,
+        preprocessed_img,
+        reference_cycle=None,
+        target_cycle=None,
+    ):
         super().__init__()
         self.extension = "png"
         self.preprocessed_ref = preprocessed_ref
         self.shifted_img = shifted_img
         self.preprocessed_img = preprocessed_img
+        self.reference_cycle = reference_cycle
+        self.target_cycle = target_cycle
         self.folder_path = ""
         self.basename = ""
         self.path_name = ""
@@ -291,6 +301,15 @@ class RefDiffFile(DataFile):
         self.preprocessed_ref = None
         self.shifted_img = None
         self.preprocessed_img = None
+        self.reference_cycle = None
+        self.target_cycle = None
+
+    @staticmethod
+    def _extract_cycle_label(value):
+        if value is None:
+            return None
+        match = re.search(r"(RT\d+)", str(value))
+        return match.group(1) if match else str(value)
 
     def save(self, folder_path, basename):
         """
@@ -333,11 +352,21 @@ class RefDiffFile(DataFile):
 
         ax1.imshow(rgb_uncorrected)
         ax1.axis("off")
-        ax1.set_title("uncorrected")
+        ref_cycle = self._extract_cycle_label(self.reference_cycle)
+        target_cycle = self._extract_cycle_label(self.target_cycle)
+        if target_cycle is None:
+            target_cycle = self._extract_cycle_label(basename)
+        title_suffix = (
+            f" ({ref_cycle} vs {target_cycle})"
+            if ref_cycle is not None and target_cycle is not None
+            else ""
+        )
+
+        ax1.set_title(f"uncorrected{title_suffix}", fontsize=42)
 
         ax2.imshow(rgb_corrected)
         ax2.axis("off")
-        ax2.set_title("corrected")
+        ax2.set_title(f"corrected{title_suffix}", fontsize=42)
 
         fig.savefig(self.path_name)
 

--- a/src/imageProcessing/alignImages.py
+++ b/src/imageProcessing/alignImages.py
@@ -43,7 +43,6 @@ from tqdm import tqdm, trange
 from core.dask_cluster import try_get_client
 from core.data_file import (
     BlockAlignmentFile,
-    BothImgRbgFile,
     EcsvFile,
     EqualizationHistogramsFile,
     JsonFile,
@@ -527,9 +526,13 @@ class RegisterGlobal(Feature):
         # thresholds corrected images for better display and saves
         preprocessed_ref[preprocessed_ref < 0] = 0
         preprocessed_img[preprocessed_img < 0] = 0
-        results_to_save.append(BothImgRbgFile(preprocessed_ref, shifted_img))
         results_to_save.append(
-            RefDiffFile(preprocessed_ref, shifted_img, preprocessed_img)
+            RefDiffFile(
+                preprocessed_ref,
+                shifted_img,
+                preprocessed_img,
+                reference_cycle=self.params.referenceFiducial,
+            )
         )
         results_to_save.append(NpyFile(shifted_img, "_2d_registered"))
 


### PR DESCRIPTION
### Motivation
- Make the reference-difference subplot titles easier to read by increasing the font size and annotating them with reference/target cycle identifiers like `RT1` or `RT99`.
- Remove the now-redundant RGB overlay export so `register_global` does not produce the extra `BothImgRbgFile` output.

### Description
- Extended `RefDiffFile` constructor to accept optional `reference_cycle` and `target_cycle` parameters and store them for plotting in `src/core/data_file.py`.
- Added a helper `_extract_cycle_label` that extracts labels matching `RT\d+` (and falls back to the raw value) and updated subplot titles to include the `(<ref> vs <target>)` suffix and `fontsize=42`.
- Removed the `BothImgRbgFile` import and its instantiation in `register_global` and instead pass `referenceFiducial` into `RefDiffFile` from `src/imageProcessing/alignImages.py`.
- Added a fallback to infer the target cycle from the output `basename` when an explicit `target_cycle` is not provided.

### Testing
- Ran `python -m compileall src/core/data_file.py src/imageProcessing/alignImages.py` which succeeded with no syntax errors.
- Ran `pytest -q tests/test_register_global.py` which could not be executed in this environment due to import path configuration raising `ModuleNotFoundError: No module named 'core'` (test collection error, not a code syntax failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1004e2171c8330a534d8bbe71faeb5)