### PR TITLE
Add 3D Z-drift visualization (XZ/YZ slice overlays) for register_global

### DIFF
--- a/src/core/data_file.py
+++ b/src/core/data_file.py
@@ -381,8 +381,8 @@ class RefDiff3DSlicesFile(DataFile):
         target_corrected_3d,
         reference_cycle=None,
         target_cycle=None,
-        n_xz_slices=4,
-        n_yz_slices=4,
+        n_xz_slices=5,
+        n_yz_slices=5,
     ):
         super().__init__()
         self.extension = "png"
@@ -430,8 +430,8 @@ class RefDiff3DSlicesFile(DataFile):
             cor_rgb = self._overlay(ref[:, :, y], cor[:, :, y])
             axes[row, 0].imshow(unc_rgb, origin="lower", aspect="auto")
             axes[row, 1].imshow(cor_rgb, origin="lower", aspect="auto")
-            axes[row, 0].set_title(f"XZ @ y={y}", fontsize=14)
-            axes[row, 1].set_title(f"XZ @ y={y}", fontsize=14)
+            axes[row, 0].set_title(f"XZ @ y={y}", fontsize=20)
+            axes[row, 1].set_title(f"XZ @ y={y}", fontsize=20)
             row += 1
 
         for x in x_positions:
@@ -439,16 +439,16 @@ class RefDiff3DSlicesFile(DataFile):
             cor_rgb = self._overlay(ref[:, x, :], cor[:, x, :])
             axes[row, 0].imshow(unc_rgb, origin="lower", aspect="auto")
             axes[row, 1].imshow(cor_rgb, origin="lower", aspect="auto")
-            axes[row, 0].set_title(f"YZ @ x={x}", fontsize=14)
-            axes[row, 1].set_title(f"YZ @ x={x}", fontsize=14)
+            axes[row, 0].set_title(f"YZ @ x={x}", fontsize=20)
+            axes[row, 1].set_title(f"YZ @ x={x}", fontsize=20)
             row += 1
 
         for i in range(axes.shape[0]):
             for j in range(axes.shape[1]):
                 axes[i, j].axis("off")
 
-        axes[0, 0].set_ylabel("Uncorrected", fontsize=16)
-        axes[0, 1].set_ylabel("Corrected", fontsize=16)
+        axes[0, 0].set_ylabel("Uncorrected", fontsize=24)
+        axes[0, 1].set_ylabel("Corrected", fontsize=24)
         fig.tight_layout()
         fig.savefig(self.path_name)
         plt.close(fig)

--- a/src/core/data_file.py
+++ b/src/core/data_file.py
@@ -373,6 +373,87 @@ class RefDiffFile(DataFile):
         plt.close(fig)
 
 
+class RefDiff3DSlicesFile(DataFile):
+    def __init__(
+        self,
+        reference_3d,
+        target_uncorrected_3d,
+        target_corrected_3d,
+        reference_cycle=None,
+        target_cycle=None,
+        n_xz_slices=4,
+        n_yz_slices=4,
+    ):
+        super().__init__()
+        self.extension = "png"
+        self.reference_3d = reference_3d
+        self.target_uncorrected_3d = target_uncorrected_3d
+        self.target_corrected_3d = target_corrected_3d
+        self.reference_cycle = reference_cycle
+        self.target_cycle = target_cycle
+        self.n_xz_slices = n_xz_slices
+        self.n_yz_slices = n_yz_slices
+
+    def delete_data(self):
+        self.reference_3d = None
+        self.target_uncorrected_3d = None
+        self.target_corrected_3d = None
+
+    @staticmethod
+    def _normalize(image):
+        max_value = np.max(image)
+        return image / max_value if max_value > 0 else image
+
+    def _overlay(self, ref_slice, target_slice):
+        ref_slice, _, _, _, _ = image_adjust(ref_slice, lower_threshold=0.5, higher_threshold=0.9999)
+        target_slice, _, _, _, _ = image_adjust(target_slice, lower_threshold=0.5, higher_threshold=0.9999)
+        return np.dstack([ref_slice, target_slice, np.zeros_like(ref_slice)])
+
+    def save(self, folder_path, basename):
+        self.folder_path = folder_path
+        self.basename = f"{basename}_referenceDifference3D"
+        self.path_name = self.folder_path + os.sep + self.basename + "." + self.extension
+
+        ref = self._normalize(self.reference_3d.astype(float))
+        unc = self._normalize(self.target_uncorrected_3d.astype(float))
+        cor = self._normalize(self.target_corrected_3d.astype(float))
+
+        _, sx, sy = ref.shape
+        y_positions = np.linspace(0, sy - 1, num=self.n_xz_slices + 2, dtype=int)[1:-1]
+        x_positions = np.linspace(0, sx - 1, num=self.n_yz_slices + 2, dtype=int)[1:-1]
+
+        fig, axes = plt.subplots(self.n_xz_slices + self.n_yz_slices, 2, figsize=(24, 48))
+
+        row = 0
+        for y in y_positions:
+            unc_rgb = self._overlay(ref[:, :, y], unc[:, :, y])
+            cor_rgb = self._overlay(ref[:, :, y], cor[:, :, y])
+            axes[row, 0].imshow(unc_rgb, origin="lower", aspect="auto")
+            axes[row, 1].imshow(cor_rgb, origin="lower", aspect="auto")
+            axes[row, 0].set_title(f"XZ @ y={y}", fontsize=14)
+            axes[row, 1].set_title(f"XZ @ y={y}", fontsize=14)
+            row += 1
+
+        for x in x_positions:
+            unc_rgb = self._overlay(ref[:, x, :], unc[:, x, :])
+            cor_rgb = self._overlay(ref[:, x, :], cor[:, x, :])
+            axes[row, 0].imshow(unc_rgb, origin="lower", aspect="auto")
+            axes[row, 1].imshow(cor_rgb, origin="lower", aspect="auto")
+            axes[row, 0].set_title(f"YZ @ x={x}", fontsize=14)
+            axes[row, 1].set_title(f"YZ @ x={x}", fontsize=14)
+            row += 1
+
+        for i in range(axes.shape[0]):
+            for j in range(axes.shape[1]):
+                axes[i, j].axis("off")
+
+        axes[0, 0].set_ylabel("Uncorrected", fontsize=16)
+        axes[0, 1].set_ylabel("Corrected", fontsize=16)
+        fig.tight_layout()
+        fig.savefig(self.path_name)
+        plt.close(fig)
+
+
 class EqualizationHistogramsFile(DataFile):
     def __init__(self, i_histogram, lower_threshold):
         super().__init__()

--- a/src/imageProcessing/alignImages.py
+++ b/src/imageProcessing/alignImages.py
@@ -48,6 +48,7 @@ from core.data_file import (
     JsonFile,
     NpyFile,
     RefDiffFile,
+    RefDiff3DSlicesFile,
 )
 from core.data_manager import load_json
 from core.parameters import ProjectionParams, RegistrationParams
@@ -534,6 +535,17 @@ class RegisterGlobal(Feature):
                 reference_cycle=self.params.referenceFiducial,
             )
         )
+        if self.params.globalAlignment == "3D":
+            shifted_target_3d = shift_image(raw_3d_img.astype(float), shift)
+            results_to_save.append(
+                RefDiff3DSlicesFile(
+                    reference_3d_img,
+                    raw_3d_img,
+                    shifted_target_3d,
+                    reference_cycle=self.params.referenceFiducial,
+                    target_cycle=self.label,
+                )
+            )
         results_to_save.append(NpyFile(shifted_img, "_2d_registered"))
 
         results_to_keep = {"shift": shift, "diffphase": diffphase, "error": error}

--- a/src/imageProcessing/alignImages.py
+++ b/src/imageProcessing/alignImages.py
@@ -543,7 +543,6 @@ class RegisterGlobal(Feature):
                     raw_3d_img,
                     shifted_target_3d,
                     reference_cycle=self.params.referenceFiducial,
-                    target_cycle=self.label,
                 )
             )
         results_to_save.append(NpyFile(shifted_img, "_2d_registered"))


### PR DESCRIPTION
### Motivation
- Provide a visual diagnostic for Z (axial) drift in 3D global registration so users can inspect the proposed Z correction and whether it improved alignment. 
- Avoid full-volume projections which are unreadable for typical stacks with large XY and small Z extents by sampling a small set of XZ and YZ slices across the volume.

### Description
- Added a new output artifact class `RefDiff3DSlicesFile` in `src/core/data_file.py` that builds a multi-panel PNG (`*_referenceDifference3D.png`) showing XZ and YZ slice overlays; left column shows uncorrected overlays and right column shows corrected overlays. 
- The class selects evenly spaced interior slice positions (default 4 XZ across Y and 4 YZ across X), normalizes images, applies existing `image_adjust` contrast logic, and composes red/green RGB overlays for comparison. 
- Integrated the new artifact into `register_global` in `src/imageProcessing/alignImages.py` so when `self.params.globalAlignment == "3D"` a Z-aware shifted 3D target (`shift_image(raw_3d_img.astype(float), shift)`) is produced and passed to `RefDiff3DSlicesFile` for saving. 
- Updated imports in `alignImages.py` to include `RefDiff3DSlicesFile` and kept existing 2D diagnostics unchanged.

### Testing
- Ran `pytest -q tests/test_register_global.py` in the workspace which failed at collection with `ModuleNotFoundError: No module named 'core'` due to test import path handling in this environment. 
- Re-ran with `PYTHONPATH=src pytest -q tests/test_register_global.py` which failed during collection due to a missing dependency `ModuleNotFoundError: No module named 'astropy'` in the current test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1057e8cc348330a7353c707172bfb4)