### PR TITLE
Annotate 3D fiducial alignment projections

### DIFF
--- a/src/imageProcessing/alignImages.py
+++ b/src/imageProcessing/alignImages.py
@@ -1247,7 +1247,12 @@ def _slice_positions(length, number_slices):
 
 
 def _combine_blocks_image_by_slices(
-    block_ref, block_target, shift_matrices=None, axis1=1, number_slices=5
+    block_ref,
+    block_target,
+    shift_matrices=None,
+    axis1=1,
+    number_slices=5,
+    return_slice_positions=False,
 ):
     ref_volume, target_volume = _reassemble_shifted_block_volumes(
         block_ref, block_target, shift_matrices=shift_matrices
@@ -1280,7 +1285,11 @@ def _combine_blocks_image_by_slices(
     for overlay in overlays:
         output_rows.extend([overlay, separator])
 
-    return np.vstack(output_rows[:-1])
+    output = np.vstack(output_rows[:-1])
+    if return_slice_positions:
+        return output, positions
+
+    return output
 
 
 def _calculate_block_similarity_matrices(
@@ -1319,7 +1328,12 @@ def _calculate_block_similarity_matrices(
 
 
 def combine_blocks_image_by_reprojection(
-    block_ref, block_target, shift_matrices=None, axis1=0
+    block_ref,
+    block_target,
+    shift_matrices=None,
+    axis1=0,
+    number_slices=5,
+    return_slice_positions=False,
 ):
     """
     This routine will overlap block_ref and block_target images block by block.
@@ -1346,6 +1360,11 @@ def combine_blocks_image_by_reprojection(
         - 0 means an XY projection
         - 1 a montage of XZ slices sampled across Y
         - 2 a montage of YZ slices sampled across X
+    number_slices : int
+        number of XZ/YZ slices to sample for the montage when axis1 is 1 or 2.
+    return_slice_positions : bool
+        when True for XZ/YZ montages, append the sampled Y/X pixel positions
+        to the returned tuple.
 
     Returns
     -------
@@ -1355,9 +1374,18 @@ def combine_blocks_image_by_reprojection(
         Structural similarity index between ref and target blocks
     """
     if axis1 in (1, 2):
-        output = _combine_blocks_image_by_slices(
-            block_ref, block_target, shift_matrices=shift_matrices, axis1=axis1
+        slice_output = _combine_blocks_image_by_slices(
+            block_ref,
+            block_target,
+            shift_matrices=shift_matrices,
+            axis1=axis1,
+            number_slices=number_slices,
+            return_slice_positions=return_slice_positions,
         )
+        if return_slice_positions:
+            output, slice_positions = slice_output
+        else:
+            output = slice_output
         ssim_as_blocks, mse_as_blocks, nrmse_as_blocks = (
             _calculate_block_similarity_matrices(
                 block_ref,
@@ -1366,6 +1394,15 @@ def combine_blocks_image_by_reprojection(
                 axis1=axis1,
             )
         )
+        if return_slice_positions:
+            return (
+                output,
+                ssim_as_blocks,
+                mse_as_blocks,
+                nrmse_as_blocks,
+                slice_positions,
+            )
+
         return output, ssim_as_blocks, mse_as_blocks, nrmse_as_blocks
 
     number_blocks_y, number_blocks_x = block_ref.shape[:2]

--- a/src/imageProcessing/alignImages3D.py
+++ b/src/imageProcessing/alignImages3D.py
@@ -381,6 +381,53 @@ def load_n_preprocess_image(
     return image_3d_0, image_3d
 
 
+def _format_xy_alignment_axis(axis):
+    axis.set_xlabel("X pixel")
+    axis.set_ylabel("Y pixel")
+    axis.tick_params(axis="both", which="both", labelsize=8)
+
+
+def _format_slice_alignment_axis(
+    axis,
+    image,
+    slice_positions,
+    number_z_planes,
+    slice_axis_label,
+    horizontal_axis_label,
+):
+    axis.set_xlabel(f"{horizontal_axis_label} pixel")
+    axis.set_ylabel("Z slice (per montage row)")
+    if slice_positions is None or len(slice_positions) == 0:
+        return
+
+    slice_height = number_z_planes
+    separator_height = 1
+    row_stride = slice_height + separator_height
+    tick_positions = [
+        i * row_stride + (slice_height - 1) / 2 for i in range(len(slice_positions))
+    ]
+    z_last = number_z_planes - 1
+    axis.set_yticks(tick_positions)
+    axis.set_yticklabels(
+        [f"{slice_axis_label}={position}\nZ=0-{z_last}" for position in slice_positions]
+    )
+    axis.tick_params(axis="both", which="both", labelsize=8)
+
+    sampled_positions = ", ".join(str(position) for position in slice_positions)
+    axis.text(
+        0.99,
+        0.02,
+        f"sampled {slice_axis_label}: {sampled_positions}",
+        transform=axis.transAxes,
+        ha="right",
+        va="bottom",
+        fontsize=8,
+        color="white",
+        bbox={"facecolor": "black", "alpha": 0.55, "edgecolor": "none"},
+    )
+    axis.set_ylim(-0.5, image.shape[0] - 0.5)
+
+
 def _align_fiducials_3d_file(
     filename_to_process,
     alignment_results_table,
@@ -470,14 +517,30 @@ def _align_fiducials_3d_file(
     # [plots shift matrices]
     fig2 = plot_3d_shift_matrices(shift_matrices, fontsize=8)
 
-    # combines blocks into a single matrix for display instead of plotting a matrix of subplots each with a block
-    outputs = []
-    for axis in range(3):
-        outputs.append(
-            combine_blocks_image_by_reprojection(
-                block_ref, block_target, shift_matrices=shift_matrices, axis1=axis
-            )
-        )
+    # combines blocks into a single matrix for display instead of plotting a matrix
+    # of subplots each with a block
+    number_blocks_y, number_blocks_x = block_ref.shape[:2]
+    output_xy = combine_blocks_image_by_reprojection(
+        block_ref, block_target, shift_matrices=shift_matrices, axis1=0
+    )
+    output_xz = combine_blocks_image_by_reprojection(
+        block_ref,
+        block_target,
+        shift_matrices=shift_matrices,
+        axis1=1,
+        number_slices=number_blocks_y,
+        return_slice_positions=True,
+    )
+    output_yz = combine_blocks_image_by_reprojection(
+        block_ref,
+        block_target,
+        shift_matrices=shift_matrices,
+        axis1=2,
+        number_slices=number_blocks_x,
+        return_slice_positions=True,
+    )
+    outputs = [output_xy, output_xz[:4], output_yz[:4]]
+    slice_positions = [None, output_xz[4], output_yz[4]]
 
     mse_matrices = [x[2] for x in outputs]
     nrmse_matrices = [x[3] for x in outputs]
@@ -496,10 +559,18 @@ def _align_fiducials_3d_file(
     for axis, output, i in zip(ax, outputs, range(3)):
         if i == 0:
             axis.imshow(output[0])
+            _format_xy_alignment_axis(axis)
         else:
             axis.imshow(output[0], origin="lower", aspect="auto")
+            _format_slice_alignment_axis(
+                axis,
+                output[0],
+                slice_positions[i],
+                block_ref.shape[2],
+                slice_axis_label="Y" if i == 1 else "X",
+                horizontal_axis_label="X" if i == 1 else "Y",
+            )
         axis.set_title(titles[i])
-        axis.axis("off")
 
     fig3.tight_layout()
 


### PR DESCRIPTION
### Motivation
- Make the number of XZ/YZ montage slices reflect the actual block grid used for 3D block alignment instead of a hard-coded value.
- Improve usability of the 3D alignment overview by exposing pixel coordinates for the XY projection and annotating the montage views with which X/Y positions were sampled and the Z slice ranges shown.

### Description
- Updated the reprojection helpers in `src/imageProcessing/alignImages.py` to accept `number_slices` and an optional `return_slice_positions` flag from `_combine_blocks_image_by_slices` and `combine_blocks_image_by_reprojection` so callers can request the sampled pixel positions for XZ/YZ montages.
- Changed `_align_fiducials_3d_file()` in `src/imageProcessing/alignImages3D.py` to: use the block grid dimensions (`number_blocks_y` / `number_blocks_x`) to set the XZ/YZ montage sample count; request and capture the sampled positions; and keep axes visible on `fig3` with labels for XY pixel coordinates.
- Added helper formatters `_format_xy_alignment_axis()` and `_format_slice_alignment_axis()` to display XY pixel axes on the left plot and annotate the XZ/YZ montage axes with sampled X/Y positions and the Z slice ranges.
- Adjusted the returned values from the reprojection functions when `return_slice_positions=True` so the caller can annotate the montages.

### Testing
- Ran `python -m compileall -f src/imageProcessing/alignImages.py src/imageProcessing/alignImages3D.py` which completed successfully.
- Ran `git diff --check` which reported no whitespace/merge issues.
- Attempted a runtime import test via `PYTHONPATH=src python - <<'PY' ...` but the quick run was blocked by a missing environment dependency (`pandas`) so a full execution test was not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a20481bf11483308b4b2e0a0ab31de6)