### PR TITLE
Handle degenerate 3D region axis lengths

### DIFF
--- a/src/imageProcessing/segmentSources3D.py
+++ b/src/imageProcessing/segmentSources3D.py
@@ -735,6 +735,45 @@ def get_mask_properties(
         return [], [], [], [], [], [], [], [], []
 
 
+
+def _safe_region_axis_lengths(region):
+    """Return finite 3D region axis lengths, falling back for degenerate objects.
+
+    scikit-image derives axis lengths from inertia-tensor eigenvalues. Very
+    small, flat, or numerically degenerate 3D labels can produce a slightly
+    negative value inside the square-root used for ``axis_minor_length`` or
+    ``axis_major_length``, which raises ``ValueError: math domain error``.
+    Treat those labels as valid detections but mark their unavailable axis
+    length as 0 so downstream roundness/elongation metrics remain safe.
+    """
+
+    try:
+        minor_axis = region.minor_axis_length
+    except ValueError:
+        print_log(
+            f"$ Warning: could not compute minor axis length for label "
+            f"{region.label}; using 0. This usually indicates a degenerate "
+            "or very small 3D object."
+        )
+        minor_axis = 0
+
+    try:
+        major_axis = region.major_axis_length
+    except ValueError:
+        print_log(
+            f"$ Warning: could not compute major axis length for label "
+            f"{region.label}; using 0. This usually indicates a degenerate "
+            "or very small 3D object."
+        )
+        major_axis = 0
+
+    if not np.isfinite(minor_axis) or minor_axis < 0:
+        minor_axis = 0
+    if not np.isfinite(major_axis) or major_axis < 0:
+        major_axis = 0
+
+    return minor_axis, major_axis
+
 def get_mask_properties_advanced(segmented_image_3d, image_3d_aligned):
     """
     Extract shape and position features from 3D labeled objects.
@@ -775,8 +814,13 @@ def get_mask_properties_advanced(segmented_image_3d, image_3d_aligned):
 
     bbox = [p.bbox for p in properties]
     area = [p.area for p in properties]
-    minor_axis_length = [p.minor_axis_length for p in properties]
-    major_axis_length = [p.major_axis_length for p in properties]
+    minor_axis_length = []
+    major_axis_length = []
+
+    for prop in properties:
+        minor_axis, major_axis = _safe_region_axis_lengths(prop)
+        minor_axis_length.append(minor_axis)
+        major_axis_length.append(major_axis)
 
     elongation = [
         major_axis_length[i] / minor_axis_length[i] if minor_axis_length[i] > 0 else 0


### PR DESCRIPTION
### Motivation
- A `ValueError: math domain error` raised from `skimage`'s axis-length properties caused the pipeline to abort when processing very small/degenerate 3D labels.
- The existing `try/except` in the watershed deblending path did not protect the later call site in `get_mask_properties_advanced()` where `p.minor_axis_length`/`p.major_axis_length` were accessed directly.
- The intent of the change is to avoid pipeline-wide failures for a single problematic segmented object and keep downstream metrics computation robust.

### Description
- Add a helper ` _safe_region_axis_lengths(region)` that wraps access to `region.minor_axis_length` and `region.major_axis_length`, catches `ValueError`, logs a warning, and returns `0` for unavailable/invalid values. 
- Replace direct list comprehensions of `p.minor_axis_length`/`p.major_axis_length` in `get_mask_properties_advanced()` with a loop that calls the helper and builds safe `minor_axis_length` and `major_axis_length` lists. 
- Ensure non-finite or negative axis values are normalized to `0` and leave elongation computed as `major / minor` but guarded to `0` when `minor <= 0`, preventing division errors. 
- Emit a clear warning with the problematic region label to aid future debugging without stopping the run.

### Testing
- `ast.parse()` on `src/imageProcessing/segmentSources3D.py` succeeded, confirming the file is syntactically valid. 
- Running `python -m pytest tests/test_localize_3d.py -q` failed at collection because the package root was not on `PYTHONPATH` in the environment. 
- Running `PYTHONPATH=src python -m pytest tests/test_localize_3d.py -q` failed in this runtime due to missing `matplotlib` dependency, so full test execution could not be completed here. 
- No unit-test failures attributable to the change were observed in this environment; the change is narrowly scoped to safely handle degenerate region properties.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a47612471a48330b535e9b01c89845a)