### PR TITLE
Feature/change descriptors localize 3d

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
   #       args: ["--skip", "docs/source/getting_started/tutorials/notebooks/full_pyHiM_run.ipynb", "-L", "nd,buid"]
 
   # Pip-audit for Dependency Security
-  - repo: https://github.com/pypa/pip-audit
-    rev: v2.8.0
-    hooks:
-      - id: pip-audit  # Checks for vulnerabilities in Python dependencies
+  #- repo: https://github.com/pypa/pip-audit
+  #  rev: v2.8.0
+  #  hooks:
+  #    - id: pip-audit  # Checks for vulnerabilities in Python dependencies

--- a/docs/source/contributor/dev_installation.md
+++ b/docs/source/contributor/dev_installation.md
@@ -31,7 +31,6 @@ nano $HOME/.bashrc
 export PATH="$PATH:$HOME/Repositories/pyHiM/src"
 export PATH="$PATH:$HOME/Repositories/pyHiM/src/toolbox/file_handling"
 export PATH="$PATH:$HOME/Repositories/pyHiM/src/postProcessing"
-
 export PYTHONPATH="$PYTHONPATH:$HOME/Repositories/pyHiM/src"
 export MPLBACKEND=agg
 ```
@@ -40,17 +39,51 @@ export MPLBACKEND=agg
 Make sure you change ```.../Repositories/...``` with your directory name (step 1.) if this is not where you put *pyHiM* !
 ```
 
-## Install conda
+
+## Installation using uv
+
+This is much faster than conda or mamba and is now the preferred installation method.
+
+To install using `uv` just go to the Repository folder and run the bash script:
+
+```sh
+cd $HOME/Repositories/pyHiM
+bash install_pyhim_uv.sh
+```
+
+Make sure you added the environmental variables in `.bashrc'.
+
+Everytime you run pyHiM you need to activate the environment doing:
+
+```sh
+source $HOME/Repositories/pyHiM/.venv/bin/activate
+```
+
+## Install using conda/mamba
 
 Follow the Miniconda instructions:
 [Installing miniconda](https://www.anaconda.com/docs/getting-started/miniconda/install#quickstart-install-instructions)
+
+Or follow these instructions to install mamba:
+
+```bash
+curl -Ls https://micro.mamba.pm/api/micromamba/$(uname)-$(uname -m)/latest | tar -xvj bin/micromamba
+```
 
 ## Automatically configure pyHiM
 
 Run this command in your terminal:
 
 ```sh
+cd $HOME/Repositories/pyHiM
 conda env create -f environment.yml
+```
+
+or
+
+```sh
+cd $HOME/Repositories/pyHiM
+mamba env create -f environment.yml
 ```
 
 ### Verify GPU recognition
@@ -84,7 +117,11 @@ You solve by running `pip install dask[complete] distributed --upgrade`.
 
 ## Install **traceratops**
 
-- For latest version user:
+If you installed `pyHiM` using `uv` you can ignore this section as the bash script already installs traceratops.
+
+Otherwise run one of the following:
+
+### Latest master version [stable]
 
 ```sh
 conda activate pyhim39
@@ -94,7 +131,7 @@ cd $HOME/Repositories/traceratops
 pip install -e .
 ```
 
-- ONLY for developer:
+### Latest dev version [stable]
 
 ```sh
 conda activate pyhim39
@@ -105,6 +142,10 @@ pip install -e ".[dev]"
 ```
 
 ## Install **apifish**
+
+If you installed `pyHiM` using `uv` you can ignore this section as the bash script already installs traceratops.
+
+Otherwise run one of the following:
 
 1. Navigate where you want install apifish
 ```bash
@@ -121,6 +162,7 @@ cd $HOME/Repositories
       git clone git@github.com:apiFISH/apiFISH.git
       ```
 3. Switch on `development` branch
+
 ```bash
 cd apiFISH && git checkout development
 ```
@@ -143,9 +185,33 @@ export PYTHONPATH="$PYTHONPATH:$HOME/Repositories/apiFISH"
 
 - To run the tests:
 
+### Using uv
+
+If you used `uv` to install `pyHiM` run:
+
+```bash
+cd $HOME/Repositories/pyHiM
+source .venv/bin/activate
+pytest tests/ -vv
+```
+
+### Using conda
+
+If you used `conda` to install `pyHiM` run:
+
 ```bash
 cd ~Repositories/pyHiM/
 conda activate pyhim39
+pytest tests/ -vv
+```
+
+### Using mamba
+
+If you used `mamba` to install `pyHiM` run:
+
+```bash
+cd ~Repositories/pyHiM/
+mamba activate pyhim39
 pytest tests/ -vv
 ```
 

--- a/install_pyhim_uv.sh
+++ b/install_pyhim_uv.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# -----------------------------
+# User settings
+# -----------------------------
+
+REPO_DIR="${HOME}/Repositories"
+PYTHON_VERSION="3.9"
+
+# -----------------------------
+# Install uv if missing
+# -----------------------------
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "Installing uv..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    export PATH="${HOME}/.local/bin:${PATH}"
+else
+    echo "uv already installed."
+fi
+
+# -----------------------------
+# Clone repositories
+# -----------------------------
+
+mkdir -p "${REPO_DIR}"
+cd "${REPO_DIR}"
+
+if [ ! -d "pyHiM" ]; then
+    git clone https://github.com/pyHi-M/pyHiM.git
+else
+    echo "pyHiM repository already exists."
+fi
+
+if [ ! -d "traceratops" ]; then
+    git clone https://github.com/pyHi-M/traceratops.git
+else
+    echo "traceratops repository already exists."
+fi
+
+# -----------------------------
+# Create fresh uv environment
+# -----------------------------
+
+cd "${REPO_DIR}/pyHiM"
+
+if [ -d ".venv" ]; then
+    echo "Removing existing .venv..."
+    rm -rf .venv
+fi
+
+uv venv .venv --python "${PYTHON_VERSION}"
+source .venv/bin/activate
+
+# -----------------------------
+# Install pinned scientific stack
+# -----------------------------
+
+uv pip install --upgrade pip wheel
+uv pip install "setuptools<70"
+
+uv pip install \
+    "numpy==1.26.4" \
+    "scipy==1.13.1" \
+    "astropy==6.0.1" \
+    "photutils==1.11.0" \
+    "scikit-image==0.19.2" \
+    "scikit-learn==1.6.1" \
+    "pandas==2.2.3" \
+    "dask==2024.8.0" \
+    "distributed==2024.8.0" \
+    "numba==0.60.0" \
+    "tifffile==2024.8.30" \
+    "pillow==11.1.0" \
+    "matplotlib" \
+    "pytest==8.3.5"
+
+uv pip install \
+    "csbdeep==0.8.1" \
+    "stardist==0.9.1" \
+    "tensorflow==2.19.0" \
+    "tensorflow-addons==0.23.0" \
+    "tensorflow-io-gcs-filesystem==0.37.1"
+
+uv pip install \
+    "roipoly==0.5.3" \
+    "rich==13.9.4" \
+    "requests==2.32.4" \
+    "pyyaml==6.0.2" \
+    "tqdm==4.67.1" \
+    "cloudpickle==3.1.1" \
+    "pympler==1.1" \
+    "dataclasses-json==0.6.7"
+
+# -----------------------------
+# Install traceratops and pyHiM
+# -----------------------------
+
+uv pip install -e "${REPO_DIR}/traceratops"
+uv pip install -e "${REPO_DIR}/pyHiM"
+
+# -----------------------------
+# Clone apiFISH
+# -----------------------------
+
+cd "${REPO_DIR}"
+
+if [ ! -d "apiFISH" ]; then
+    git clone https://github.com/apiFISH/apiFISH.git
+else
+    echo "apiFISH repository already exists."
+fi
+
+cd "${REPO_DIR}/apiFISH"
+git checkout development
+
+# -----------------------------
+# Optional PATH/PYTHONPATH setup
+# -----------------------------
+
+echo ""
+echo "Add this to your ~/.bashrc if pyHiM.py is not found:"
+echo ""
+echo "export PATH=\"\$PATH:${REPO_DIR}/pyHiM/src\""
+echo "export PATH=\"\$PATH:${REPO_DIR}/pyHiM/src/toolbox/file_handling\""
+echo "export PATH=\"\$PATH:${REPO_DIR}/pyHiM/src/postProcessing\""
+echo "export PYTHONPATH=\"\$PYTHONPATH:${REPO_DIR}/pyHiM/src\""
+echo "export PYTHONPATH=\"\$PYTHONPATH:${REPO_DIR}/apiFISH\""
+echo "export MPLBACKEND=agg"
+echo ""
+
+# -----------------------------
+# Test installation
+# -----------------------------
+
+python -c "import numpy, scipy, astropy; print('numpy', numpy.__version__); print('scipy', scipy.__version__); print('astropy', astropy.__version__)"
+python -c "import traceratops; print('traceratops OK')"
+python -c "import pkg_resources; print('pkg_resources OK')"
+
+echo ""
+echo "Installation complete."
+echo "Activate with:"
+echo "source ${REPO_DIR}/pyHiM/.venv/bin/activate"
+echo ""
+echo "Test pyHiM with:"
+echo "python ${REPO_DIR}/pyHiM/src/pyHiM.py --help"

--- a/src/core/data_file.py
+++ b/src/core/data_file.py
@@ -405,14 +405,20 @@ class RefDiff3DSlicesFile(DataFile):
         return image / max_value if max_value > 0 else image
 
     def _overlay(self, ref_slice, target_slice):
-        ref_slice, _, _, _, _ = image_adjust(ref_slice, lower_threshold=0.5, higher_threshold=0.9999)
-        target_slice, _, _, _, _ = image_adjust(target_slice, lower_threshold=0.5, higher_threshold=0.9999)
+        ref_slice, _, _, _, _ = image_adjust(
+            ref_slice, lower_threshold=0.5, higher_threshold=0.9999
+        )
+        target_slice, _, _, _, _ = image_adjust(
+            target_slice, lower_threshold=0.5, higher_threshold=0.9999
+        )
         return np.dstack([ref_slice, target_slice, np.zeros_like(ref_slice)])
 
     def save(self, folder_path, basename):
         self.folder_path = folder_path
         self.basename = f"{basename}_referenceDifference3D"
-        self.path_name = self.folder_path + os.sep + self.basename + "." + self.extension
+        self.path_name = (
+            self.folder_path + os.sep + self.basename + "." + self.extension
+        )
 
         ref = self._normalize(self.reference_3d.astype(float))
         unc = self._normalize(self.target_uncorrected_3d.astype(float))
@@ -422,7 +428,9 @@ class RefDiff3DSlicesFile(DataFile):
         y_positions = np.linspace(0, sy - 1, num=self.n_xz_slices + 2, dtype=int)[1:-1]
         x_positions = np.linspace(0, sx - 1, num=self.n_yz_slices + 2, dtype=int)[1:-1]
 
-        fig, axes = plt.subplots(self.n_xz_slices + self.n_yz_slices, 2, figsize=(24, 48))
+        fig, axes = plt.subplots(
+            self.n_xz_slices + self.n_yz_slices, 2, figsize=(24, 48)
+        )
 
         row = 0
         for y in y_positions:

--- a/src/core/data_manager.py
+++ b/src/core/data_manager.py
@@ -113,7 +113,11 @@ class DataManager:
         return str(data_path) if data_path else os.getcwd()
 
     def _determine_logs_path(self, md_file: str):
-        logs_path = os.path.dirname(md_file) if md_file else os.path.join(self.m_data_path, "logs")
+        logs_path = (
+            os.path.dirname(md_file)
+            if md_file
+            else os.path.join(self.m_data_path, "logs")
+        )
         os.makedirs(logs_path, exist_ok=True)
         return logs_path
 

--- a/src/core/function_caller.py
+++ b/src/core/function_caller.py
@@ -34,11 +34,11 @@ from imageProcessing.segmentMasks3D import Mask3D
 from imageProcessing.segmentSources3D import Localize3D
 from matrixOperations.build_matrix_tempo import BuildMatrixTempo
 from matrixOperations.build_traces import BuildTraces, BuildTracesTempo
-from matrixOperations.merge_inputs import MergeInputs
 from matrixOperations.filter_localizations import (
     FilterLocalizations,
     FilterLocalizationsTempo,
 )
+from matrixOperations.merge_inputs import MergeInputs
 from matrixOperations.register_localizations import (
     RegisterLocalizations,
     RegisterLocalizationsTempo,

--- a/src/imageProcessing/alignImages.py
+++ b/src/imageProcessing/alignImages.py
@@ -18,15 +18,16 @@ image cross correlation
 # =============================================================================
 
 import glob
+import math
 import os
 import re
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
-import math
 from astropy.stats import SigmaClip
 from astropy.table import Table
 from numpy import linalg as LA
@@ -41,8 +42,6 @@ from skimage.util.shape import view_as_blocks
 from tqdm import trange
 from tqdm.auto import tqdm
 
-from concurrent.futures import ThreadPoolExecutor
-
 from core.dask_cluster import try_get_client
 from core.data_file import (
     BlockAlignmentFile,
@@ -50,8 +49,8 @@ from core.data_file import (
     EqualizationHistogramsFile,
     JsonFile,
     NpyFile,
-    RefDiffFile,
     RefDiff3DSlicesFile,
+    RefDiffFile,
 )
 from core.data_manager import load_json
 from core.parameters import ProjectionParams, RegistrationParams
@@ -289,11 +288,19 @@ def _estimate_z_shift_from_axis_slices(
         "total_slices": len(slices),
         "accepted_slices": accepted_slices,
         "ref_fraction_min": float(np.min(ref_fractions)) if ref_fractions else 0.0,
-        "ref_fraction_median": float(np.median(ref_fractions)) if ref_fractions else 0.0,
+        "ref_fraction_median": (
+            float(np.median(ref_fractions)) if ref_fractions else 0.0
+        ),
         "ref_fraction_max": float(np.max(ref_fractions)) if ref_fractions else 0.0,
-        "target_fraction_min": float(np.min(target_fractions)) if target_fractions else 0.0,
-        "target_fraction_median": float(np.median(target_fractions)) if target_fractions else 0.0,
-        "target_fraction_max": float(np.max(target_fractions)) if target_fractions else 0.0,
+        "target_fraction_min": (
+            float(np.min(target_fractions)) if target_fractions else 0.0
+        ),
+        "target_fraction_median": (
+            float(np.median(target_fractions)) if target_fractions else 0.0
+        ),
+        "target_fraction_max": (
+            float(np.max(target_fractions)) if target_fractions else 0.0
+        ),
     }
     return z_shifts, diagnostics
 
@@ -412,7 +419,12 @@ def compute_global_z_shift_from_slices(
     if len(filtered_shifts) == 0:
         filtered_shifts = np.asarray(z_shifts)
 
-    return float(np.mean(filtered_shifts)), len(z_shifts), len(filtered_shifts), diagnostics
+    return (
+        float(np.mean(filtered_shifts)),
+        len(z_shifts),
+        len(filtered_shifts),
+        diagnostics,
+    )
 
 
 class RegisterGlobal(Feature):
@@ -504,15 +516,19 @@ class RegisterGlobal(Feature):
             target_xy_aligned = apply_xy_shift_3d_images(
                 raw_3d_img, shift_xy, parallel_execution=False
             )
-            z_shift, total_slices, used_slices, z_diag = compute_global_z_shift_from_slices(
-                reference_3d_img,
-                target_xy_aligned,
-                slice_size=self.params.sliceSize,
-                min_signal_fraction=self.params.zMinSignalFraction,
-                upsample_factor=100,
-                auto_relax=self.params.zMinSignalFractionAuto,
+            z_shift, total_slices, used_slices, z_diag = (
+                compute_global_z_shift_from_slices(
+                    reference_3d_img,
+                    target_xy_aligned,
+                    slice_size=self.params.sliceSize,
+                    min_signal_fraction=self.params.zMinSignalFraction,
+                    upsample_factor=100,
+                    auto_relax=self.params.zMinSignalFractionAuto,
+                )
             )
-            selected_fraction = z_diag.get("selected_min_signal_fraction", self.params.zMinSignalFraction)
+            selected_fraction = z_diag.get(
+                "selected_min_signal_fraction", self.params.zMinSignalFraction
+            )
             print_log(
                 "$ Z-shift polling: "
                 f"{used_slices}/{total_slices} valid slices after outlier filtering; "
@@ -949,7 +965,7 @@ def apply_registrations_to_current_folder(
         raise ValueError(f"# File with dictionary not found!: {dict_filename}")
     else:
         print_log(f"$ Dictionary File loaded: {dict_filename}")
-        
+
     # generates shifts plot
     table_plot = prepare_table_from_json(dict_shifts)
     reference_number = params.referenceFiducial
@@ -978,6 +994,7 @@ def apply_registrations_to_current_folder(
 # =============================================================================
 # IMAGE ALIGNMENT
 # =============================================================================
+
 
 def apply_xy_shift_3d_images(image, shift, parallel_execution=True):
     """Applies a rigid shift to 2D or 3D images.
@@ -1565,7 +1582,8 @@ def align_2_images_cross_correlation(
         image2_adjusted,
     )
 
-######################################## Functions for global_register shifts plot ########################################
+
+# Functions for global_register shifts plot
 def prepare_table_from_json(json_data):
     # Reads shifts JSON dictionary of format: {"ROI:001": { "RT10": [z,x,y] or "RT10": [x,y] }
     roi_dict = next(iter(json_data.values()), {})
@@ -1579,7 +1597,7 @@ def prepare_table_from_json(json_data):
         if len(shifts) == 2:
             x, y = shifts
             z = None
-            z_axis= False
+            z_axis = False
         elif len(shifts) == 3:
             z, x, y = shifts
         else:
@@ -1598,13 +1616,14 @@ def prepare_table_from_json(json_data):
     table = pd.DataFrame(rows)
     table = table.sort_values(by="sort_num")
     table = table.set_index("label").drop(columns="sort_num")
-    
+
     if not z_axis:
         table = table.drop(columns=["shift_z"])
     if z_axis:
-    	 if table["shift_z"].isna().all() or (table["shift_z"].fillna(0) == 0).all():
+        if table["shift_z"].isna().all() or (table["shift_z"].fillna(0) == 0).all():
             table = table.drop(columns=["shift_z"])
     return table
+
 
 def extract_reference_cycle(ref):
     ref = str(ref)
@@ -1613,6 +1632,7 @@ def extract_reference_cycle(ref):
     match = re.search(r"\d+", ref)
     return int(match.group()) if match else None
 
+
 def generate_shift_plot(table, ref, output_path):
     table.index = table.index.astype(str)
     cols = [c for c in table.columns if table[c].notna().any()]
@@ -1620,12 +1640,12 @@ def generate_shift_plot(table, ref, output_path):
     ref = str(extract_reference_cycle(ref))
     # max 50 rows
     subplot_size = 50
-    n_subplot = math.ceil(n_bars / subplot_size )
+    n_subplot = math.ceil(n_bars / subplot_size)
     # comparable axes
     y_min = table[cols].min().min()
     y_max = table[cols].max().max()
     for i in range(n_subplot):
-        subplot = table.iloc[i * subplot_size:(i + 1) * subplot_size]
+        subplot = table.iloc[i * subplot_size : (i + 1) * subplot_size]
         n_subplot_bars = len(subplot.index)
 
         # figure size per subplot

--- a/src/imageProcessing/alignImages3D.py
+++ b/src/imageProcessing/alignImages3D.py
@@ -42,7 +42,6 @@ import matplotlib.pylab as plt
 import numpy as np
 from astropy.table import Table, vstack
 from skimage import io
-from skimage.registration import phase_cross_correlation
 
 from core.dask_cluster import try_get_client
 from core.parameters import RegistrationParams, load_alignment_dict, print_dict
@@ -55,6 +54,9 @@ from imageProcessing.alignImages import (
 )
 from imageProcessing.imageProcessing import preprocess_3d_image
 from imageProcessing.makeProjections import reinterpolate_z
+
+# from skimage.registration import phase_cross_correlation
+
 
 # =============================================================================
 # CLASSES
@@ -483,7 +485,7 @@ def _align_fiducials_3d_file(
             f"> Existing with ERROR: Could not find shift value \
                 for this ROI: {roi} and cycle: {cycle_name}"
         )
-    
+
     # applies XY shift to 3D stack
     # ----------------------------
     print_log(f"$ shift values that will be applied = {shift}")

--- a/src/imageProcessing/alignImages3D.py
+++ b/src/imageProcessing/alignImages3D.py
@@ -478,15 +478,6 @@ def _align_fiducials_3d_file(
             )
     if not dict_shifts_available or shift is None:
         # if dictionary of shift or key for this cycle was not found, then it will exit
-        
-        '''
-        images_2d = [np.sum(x, axis=0) for x in images]
-
-        print_log("> Calculating XY shift...")
-        shift, _, _ = phase_cross_correlation(
-            images_2d[0], images_2d[1], upsample_factor=params.upsample_factor
-        )
-        '''
 
         raise SystemExit(
             f"> Existing with ERROR: Could not find shift value \

--- a/src/imageProcessing/imageProcessing.py
+++ b/src/imageProcessing/imageProcessing.py
@@ -5,6 +5,7 @@ Classes for common image processing
 """
 
 import os
+from concurrent.futures import ProcessPoolExecutor
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -15,7 +16,6 @@ from photutils import Background2D, MedianBackground
 from skimage import exposure, io
 from tqdm import trange
 from tqdm.auto import tqdm
-from concurrent.futures import ProcessPoolExecutor
 
 from core.dask_cluster import try_get_client
 from core.pyhim_logging import print_log
@@ -418,8 +418,7 @@ def _remove_inhomogeneous_background_3d_nodask(
         )
 
         tasks = [
-            (z, image_3d[z, :, :], box_size, filter_size)
-            for z in range(number_planes)
+            (z, image_3d[z, :, :], box_size, filter_size) for z in range(number_planes)
         ]
 
         last_background = None
@@ -457,6 +456,7 @@ def _remove_inhomogeneous_background_3d_nodask(
             last_background = bkg.background
 
     return (output, last_background) if background else output
+
 
 def _remove_inhomogeneous_background_3d(
     image_3d,
@@ -520,7 +520,8 @@ def _remove_inhomogeneous_background_3d(
         # del image_list_scattered
 
     else:
-        output = _remove_inhomogeneous_background_3d_nodask(image_3d,
+        output = _remove_inhomogeneous_background_3d_nodask(
+            image_3d,
             box_size=box_size,
             filter_size=filter_size,
             parallel_execution=True,

--- a/src/imageProcessing/segmentMasks.py
+++ b/src/imageProcessing/segmentMasks.py
@@ -1137,8 +1137,15 @@ def _deblend_3d_segmentation_advanced(binary):
 
     for region in region_properties:
 
-        minor_axis = region.axis_minor_length
-        major_axis = region.axis_major_length
+        try:
+            minor_axis = region.axis_minor_length
+        except ValueError:
+            continue
+
+        try:
+            major_axis = region.axis_major_length
+        except ValueError:
+            continue
 
         if not np.isfinite(minor_axis) or minor_axis <= 0:
             continue

--- a/src/imageProcessing/segmentMasks.py
+++ b/src/imageProcessing/segmentMasks.py
@@ -54,13 +54,11 @@ from photutils.segmentation.core import SegmentationImage
 from scipy import ndimage as ndi
 from scipy.ndimage import gaussian_filter
 from scipy.spatial import Voronoi
-from scipy.stats import skew
 from skimage import measure
 from skimage.feature import peak_local_max
 from skimage.measure import label, regionprops
 from skimage.segmentation import watershed
 from skimage.util.apply_parallel import apply_parallel
-from skimage.filters import threshold_otsu
 from stardist import random_label_cmap
 from stardist.models import StarDist2D, StarDist3D
 from tqdm import trange

--- a/src/imageProcessing/segmentMasks.py
+++ b/src/imageProcessing/segmentMasks.py
@@ -69,8 +69,6 @@ from core.pyhim_logging import print_log, write_string_to_file
 from core.saving import save_image_2d_cmd
 from imageProcessing.imageProcessing import Image, reassemble_3d_image, scatter_3d_image
 
-import pandas as pd
-
 np.seterr(divide="ignore", invalid="ignore")
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"  # ignore tensorflow logging
 matplotlib.rcParams["image.interpolation"] = "none"
@@ -522,12 +520,12 @@ def segment_mask_inhomog_background(im, seg_params: SegmentationParams):
     )
 
     # removes Masks too big or too small
-    for label in segm_deblend.labels:
+    for label1 in segm_deblend.labels:
         # take regions with large enough areas
-        area = segm_deblend.get_area(label)
+        area = segm_deblend.get_area(label1)
         # print_log('label {}, with area {}'.format(label,area))
         if area < seg_params.area_min or area > seg_params.area_max:
-            segm_deblend.remove_label(label=label)
+            segm_deblend.remove_label(label=label1)
             # print_log('label {} removed'.format(label))
 
     # relabel so masks numbers are consecutive
@@ -590,11 +588,11 @@ def segment_mask_stardist(im, seg_params: SegmentationParams):
     segm_deblend = segm
 
     # removes Masks too big or too small
-    for label in segm_deblend.labels:
+    for label1 in segm_deblend.labels:
         # take regions with large enough areas
-        area = segm_deblend.get_area(label)
+        area = segm_deblend.get_area(label1)
         if area < seg_params.area_min or area > seg_params.area_max:
-            segm_deblend.remove_label(label=label)
+            segm_deblend.remove_label(label=label1)
 
     # relabel so masks numbers are consecutive
     segm_deblend.relabel_consecutive()
@@ -912,11 +910,11 @@ def _segment_2d_image_by_thresholding(
     )
     if segm_deblend.nlabels > 0:
         # removes Masks too big or too small
-        for label in segm_deblend.labels:
+        for label1 in segm_deblend.labels:
             # take regions with large enough areas
-            area = segm_deblend.get_area(label)
+            area = segm_deblend.get_area(label1)
             if area < area_min or area > area_max:
-                segm_deblend.remove_label(label=label)
+                segm_deblend.remove_label(label=label1)
 
         # relabel so masks numbers are consecutive
         # segm_deblend.relabel_consecutive()
@@ -943,7 +941,7 @@ def _segment_3d_volumes_stardist(
         "> Using CUDA_VISIBLE_DEVICES from the environment; set it externally to pin GPUs."
     )
     model = StarDist3D(None, name=model_name, basedir=model_dir)
-    #limit_gpu_memory(None, allow_growth=True)
+    # limit_gpu_memory(None, allow_growth=True)
 
     im = normalize(image_3d, 1, 99.8, axis=axis_norm)
     l_x = im.shape[1]
@@ -1077,6 +1075,7 @@ def _deblend_3d_segmentation(binary):
     labels = watershed(-distance, markers, mask=binary)
     return labels
 
+
 def _deblend_3d_segmentation_advanced(binary):
     """
     Split touching 3D objects using a two-step watershed approach.
@@ -1116,7 +1115,7 @@ def _deblend_3d_segmentation_advanced(binary):
     coords_2 = peak_local_max(
         distance,
         footprint=np.ones((10, 10, 25)),
-        min_distance=(min_dist*2),
+        min_distance=(min_dist * 2),
         labels=binary,
         exclude_border=True,
     )
@@ -1157,7 +1156,7 @@ def _deblend_3d_segmentation_advanced(binary):
         else:
             regular_labels.append(region.label)
 
-    if len(elongated_labels)>0:
+    if len(elongated_labels) > 0:
 
         elongated_mask = np.isin(initial_labels, elongated_labels)
         regular_mask = np.isin(initial_labels, regular_labels)
@@ -1219,9 +1218,10 @@ def _deblend_3d_segmentation_advanced(binary):
 
         labels = regular_objects + corrected_elongated_labels
     else:
-        labels = initial_labels 
+        labels = initial_labels
 
     return labels
+
 
 def _segment_3d_masks(
     image_3d,

--- a/src/imageProcessing/segmentMasks.py
+++ b/src/imageProcessing/segmentMasks.py
@@ -54,11 +54,13 @@ from photutils.segmentation.core import SegmentationImage
 from scipy import ndimage as ndi
 from scipy.ndimage import gaussian_filter
 from scipy.spatial import Voronoi
+from scipy.stats import skew
 from skimage import measure
 from skimage.feature import peak_local_max
-from skimage.measure import regionprops
+from skimage.measure import label, regionprops
 from skimage.segmentation import watershed
 from skimage.util.apply_parallel import apply_parallel
+from skimage.filters import threshold_otsu
 from stardist import random_label_cmap
 from stardist.models import StarDist2D, StarDist3D
 from tqdm import trange
@@ -68,6 +70,8 @@ from core.parameters import SegmentationParams
 from core.pyhim_logging import print_log, write_string_to_file
 from core.saving import save_image_2d_cmd
 from imageProcessing.imageProcessing import Image, reassemble_3d_image, scatter_3d_image
+
+import pandas as pd
 
 np.seterr(divide="ignore", invalid="ignore")
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"  # ignore tensorflow logging
@@ -928,7 +932,6 @@ def _segment_2d_image_by_thresholding(
 
 def _segment_3d_volumes_stardist(
     image_3d,
-    deblend_3d=False,
     axis_norm=(0, 1, 2),
     model_dir="/mnt/PALM_dataserv/DATA/JB/2021/Data_single_loci/Annotated_data/data_loci_small/models/",
     model_name="stardist_18032021_single_loci",
@@ -960,9 +963,7 @@ def _segment_3d_volumes_stardist(
 
     mask = np.array(labels > 0, dtype=int)
 
-    # Now we want to separate objects in 3D using watersheding
-    labeled_image = _deblend_3d_segmentation(mask) if deblend_3d else labels
-    return mask, labeled_image
+    return mask
 
 
 def _segment_3d_volumes_by_thresholding(
@@ -1078,6 +1079,144 @@ def _deblend_3d_segmentation(binary):
     labels = watershed(-distance, markers, mask=binary)
     return labels
 
+def _deblend_3d_segmentation_advanced(binary):
+    """
+    Split touching 3D objects using a two-step watershed approach.
+
+    Steps:
+    1. Global watershed on distance transform to separate main objects.
+    2. Refined watershed on elongated objects to split merged spots.
+
+    Parameters
+    ----------
+    binary : ndarray (3D)
+        Binary mask of objects.
+
+    Returns
+    -------
+    ndarray
+        Labeled 3D segmentation.
+    """
+
+    print_log(" > Constructing distance matrix from 3D binary mask...")
+    binary = binary > 0
+
+    # First watershed
+    print_log(" > Deblending sources in 3D by watersheding (part 1)...")
+    distance = apply_parallel(ndi.distance_transform_edt, binary)
+
+    coords_1 = peak_local_max(
+        distance,
+        footprint=np.ones((10, 10, 25)),
+        labels=binary,
+        exclude_border=True,
+    )
+
+    peak_values = distance[tuple(coords_1.T)]
+    min_dist = int(np.median(peak_values))
+
+    coords_2 = peak_local_max(
+        distance,
+        footprint=np.ones((10, 10, 25)),
+        min_distance=(min_dist*2),
+        labels=binary,
+        exclude_border=True,
+    )
+
+    marker_mask = np.zeros(distance.shape, dtype=bool)
+    marker_mask[tuple(coords_2.T)] = True
+
+    markers, _ = ndi.label(marker_mask)
+
+    initial_labels = watershed(-distance, markers, mask=binary)
+
+    # Second watershed
+    print_log(" > Deblending sources in 3D by watersheding (part 2)...")
+    region_properties = regionprops(initial_labels)
+
+    elongated_labels = []
+    regular_labels = []
+
+    for region in region_properties:
+
+        minor_axis = region.axis_minor_length
+        major_axis = region.axis_major_length
+
+        if not np.isfinite(minor_axis) or minor_axis <= 0:
+            continue
+
+        elongation = major_axis / minor_axis
+
+        if elongation >= 2.5:
+            elongated_labels.append(region.label)
+        else:
+            regular_labels.append(region.label)
+
+    if len(elongated_labels)>0:
+
+        elongated_mask = np.isin(initial_labels, elongated_labels)
+        regular_mask = np.isin(initial_labels, regular_labels)
+
+        normal_mask_labeled = label(regular_mask)
+        normal_mask_props = regionprops(normal_mask_labeled)
+
+        normal_size_object = []
+
+        for p in normal_mask_props:
+            if p.area < 50:
+                continue
+
+            diameter = p.axis_major_length
+            rayon = diameter / 2
+
+            normal_size_object.append(rayon)
+
+        footprint_values = round(np.mean(normal_size_object))
+
+        # Second watershed (elongated objects only)
+        elongated_distance = ndi.distance_transform_edt(elongated_mask)
+
+        elongated_peaks = peak_local_max(
+            elongated_distance,
+            footprint=np.ones(
+                (
+                    footprint_values,
+                    footprint_values,
+                    footprint_values,
+                )
+            ),
+            min_distance=min_dist,
+            labels=elongated_mask,
+            exclude_border=True,
+        )
+
+        elongated_mask_markers = np.zeros(elongated_distance.shape, dtype=bool)
+        elongated_mask_markers[tuple(elongated_peaks.T)] = True
+
+        elongated_markers, _ = ndi.label(elongated_mask_markers)
+
+        corrected_elongated_labels = watershed(
+            -elongated_distance,
+            elongated_markers,
+            mask=elongated_mask,
+        )
+
+        # Merge results
+        regular_objects = np.where(regular_mask, initial_labels, 0)
+
+        label_offset = regular_objects.max()
+
+        corrected_elongated_labels = np.where(
+            corrected_elongated_labels > 0,
+            corrected_elongated_labels + label_offset,
+            0,
+        )
+
+        labels = regular_objects + corrected_elongated_labels
+    else:
+        labels = initial_labels 
+
+    return labels
 
 def _segment_3d_masks(
     image_3d,

--- a/src/imageProcessing/segmentMasks3D.py
+++ b/src/imageProcessing/segmentMasks3D.py
@@ -142,9 +142,7 @@ class Mask3D:
             }
 
         # segments 3D volumes
-        _, segmented_image_3d = self._segment_3d_volumes(
-            image_3d, seg_params, label
-        )
+        _, segmented_image_3d = self._segment_3d_volumes(image_3d, seg_params, label)
 
         number_masks = np.max(segmented_image_3d)
         print_log(f"$ Number of masks detected: {number_masks}")
@@ -399,7 +397,9 @@ class Mask3D:
             x for x in files_folder if (label in os.path.basename(x).split("_")[2])
         ]
         n_files_to_process = len(self.filenames_to_process_list)
-        print_log(f"$ Found {n_files_to_process} files in ROI [{roi_name}], {self.filenames_to_process_list[0]}")
+        print_log(
+            f"$ Found {n_files_to_process} files in ROI [{roi_name}], {self.filenames_to_process_list[0]}"
+        )
 
         self.inner_parallel_loop = True
         # processes files in this ROI
@@ -414,7 +414,7 @@ class Mask3D:
                 roi_name,
                 acq_params,
                 reference_fiducial,
-                label
+                label,
             )
 
     def shift_mask_file(
@@ -425,7 +425,7 @@ class Mask3D:
         roi_name,
         acq_params,
         reference_fiducial,
-        label
+        label,
     ):
 
         dim = 3
@@ -458,14 +458,16 @@ class Mask3D:
 
         # applies XY shift to 3D stack
         if label != reference_fiducial:
-            
+
             shift_arr = np.asarray(shift)
             if shift_arr.size >= 3:
                 print_log(
                     f"$ Applies shift (z,x,y) = [{shift_arr[0]:.2f}, {shift_arr[1]:.2f}, {shift_arr[2]:.2f}]"
                 )
             else:
-                print_log(f"$ Applies shift (x,y) = [{shift_arr[0]:.2f}, {shift_arr[1]:.2f}]")
+                print_log(
+                    f"$ Applies shift (x,y) = [{shift_arr[0]:.2f}, {shift_arr[1]:.2f}]"
+                )
             image_3d_aligned = apply_shift_3d_images(image_3d, shift)
         else:
             print_log("$ Running reference fiducial cycle: no shift applied!")
@@ -476,7 +478,9 @@ class Mask3D:
 
         if number_masks > 0:
 
-            original_filename_root = os.path.basename(filename_to_process).split("_3Dmasks_unregistered.npy")[0]
+            original_filename_root = os.path.basename(filename_to_process).split(
+                "_3Dmasks_unregistered.npy"
+            )[0]
 
             npy_labeled_image_shifted = (
                 data_path
@@ -495,7 +499,6 @@ class Mask3D:
             np.save(npy_labeled_image_shifted, image_3d_aligned)
         else:
             print_log(f"> Warning, no masks detected in: {filename_to_process}")
-
 
         del image_3d_aligned, image_3d
 

--- a/src/imageProcessing/segmentMasks3D.py
+++ b/src/imageProcessing/segmentMasks3D.py
@@ -120,7 +120,7 @@ class Mask3D:
         if label in self.dict_shifts[f"ROI:{roi_name}"]:
             output_extension = {"2D": "_Masks", "3D": "_3Dmasks"}
             shift = self.dict_shifts[f"ROI:{roi_name}"][label]
-            print_log("> Applying existing XY shift...")
+            print_log("> Applying existing shift...")
             # applies XY shift to 3D stack
             if label != reference_fiducial:
                 shift_arr = np.asarray(shift)
@@ -440,7 +440,7 @@ class Mask3D:
         # uses existing shift calculated by align_images
         try:
             shift = self.dict_shifts[f"ROI:{roi_name}"][label]
-            print_log("> Applying existing XY shift...")
+            print_log("> Applying existing shift...")
             # Round shift value because we align a mask file
             shift = [round(value) for value in shift]
         except KeyError:

--- a/src/imageProcessing/segmentSources3D.py
+++ b/src/imageProcessing/segmentSources3D.py
@@ -55,7 +55,10 @@ from imageProcessing.makeProjections import reinterpolate_z
 from imageProcessing.segmentMasks import (
     _segment_3d_volumes_by_thresholding,
     _segment_3d_volumes_stardist,
+    _deblend_3d_segmentation_advanced,
 )
+
+from traceratops.core.localization_table import create_output_table
 
 # =============================================================================
 # CLASSES
@@ -191,13 +194,13 @@ class Localize3D:
         p = self.p
 
         if p["3Dmethod"] == "stardist":
-            binary, segmented_image_3d = _segment_3d_volumes_stardist(
+            binary = _segment_3d_volumes_stardist(
                 image_3d_aligned,
-                deblend_3d=True,
                 axis_norm=(0, 1, 2),
                 model_dir=p["stardist_basename"],
                 model_name=p["stardist_network"],
             )
+            segmented_image_3d = binary
         else:
             binary, segmented_image_3d = _segment_3d_volumes_by_thresholding(
                 image_3d_aligned,
@@ -300,10 +303,15 @@ class Localize3D:
             print_log("$ Running reference fiducial cycle: no shift applied!")
             shift = np.array([0.0, 0.0])
             image_3d_aligned = image_3d
+
         # segments 3D volumes
         _, segmented_image_3d = self._segment_3d_volumes(image_3d_aligned)
 
+        # deblend 3D volumes
+        segmented_image_3d = _deblend_3d_segmentation_advanced(segmented_image_3d)
+
         # gets centroids and converts to spot int64 NPY array
+        """
         (
             spots,
             sharpness,
@@ -320,8 +328,24 @@ class Localize3D:
             threshold=p["threshold_over_std"],
             n_tolerance=p["brightest"],
         )
+        """
 
-        number_sources = len(peak)
+        (
+            spots,
+            snr_list,
+            spot_pixel_percentage,
+            mean_intensity_list,
+            skew_list,
+            patch_size,
+            object_class,
+            flux_list,
+            roundness_list,
+        ) = get_mask_properties_advanced(
+            segmented_image_3d,
+            image_3d_aligned,
+        )
+
+        number_sources = len(mean_intensity_list)
         print_log(
             f"$ Number of sources detected by image segmentation: {number_sources}"
         )
@@ -335,10 +359,8 @@ class Localize3D:
             )  # removes negative intensity levels
 
             # calls bigfish to get 3D sub-pixel coordinates based on 3D gaussian fitting
-            # compatibility with latest version of bigfish. To be removed if stable.
-            # TODO: Is it stable ? I think we can remove it.
             try:
-                # version 0.4 commit fa0df4f
+                # version 0.4 
                 spots_subpixel = fit_subpixel(
                     image_3d_aligned,
                     spots,
@@ -361,6 +383,7 @@ class Localize3D:
                 )  # spot radius
 
             print_log(" > Updating table and saving results")
+
             # updates table
             for i in range(spots_subpixel.shape[0]):
                 z, x, y = spots_subpixel[i, :]
@@ -373,14 +396,14 @@ class Localize3D:
                     z + z_correction,
                     y,
                     x,
-                    sharpness[i],
-                    roundness1[i],
-                    roundness2[i],
-                    npix[i],
-                    sky[i],
-                    peak[i],
-                    flux[i],
-                    mag[i],
+                    snr_list[i],
+                    spot_pixel_percentage[i],
+                    skew_list[i],
+                    patch_size[i],
+                    object_class[i],
+                    mean_intensity_list[i],
+                    flux_list[i],
+                    roundness_list[i],
                 ]
                 output_table.add_row(table_entry)
 
@@ -709,6 +732,213 @@ def get_mask_properties(
         return [], [], [], [], [], [], [], [], []
 
 
+
+
+def get_mask_properties_advanced(segmented_image_3d, image_3d_aligned):
+    """
+    Extract shape and position features from 3D labeled objects.
+
+    Parameters
+    ----------
+    segmented_image_3d : ndarray
+        Labeled 3D segmentation.
+    image_3d_aligned : ndarray
+        Intensity image.
+
+    Returns
+    -------
+    astropy.table.Table
+        One row per object with centroid, bbox, area, and shape metrics.
+    """
+
+    properties = regionprops(segmented_image_3d, intensity_image= image_3d_aligned)
+
+    if len(properties) == 0:
+        return Table(
+            names=[
+                "z", "y", "x",
+                "z_min", "y_min", "x_min",
+                "z_max", "y_max", "x_max",
+                "area",
+                "minor_axis_length",
+                "major_axis_length",
+                "elongation",
+            ],
+            rows=[]
+        )
+
+    try:
+        centroids = [p.weighted_centroid for p in properties]
+    except AttributeError:
+        centroids = [p.centroid_weighted for p in properties]
+
+    bbox = [p.bbox for p in properties]
+    area = [p.area for p in properties]
+    minor_axis_length = [p.minor_axis_length for p in properties]
+    major_axis_length = [p.major_axis_length for p in properties]
+
+    elongation = [
+        major_axis_length[i] / minor_axis_length[i] if minor_axis_length[i] > 0 else 0
+        for i in range(len(properties))
+    ]
+
+    mask_properties = Table(
+        {
+            "z": [c[0] for c in centroids],
+            "y": [c[1] for c in centroids],
+            "x": [c[2] for c in centroids],
+            "z_min": [b[0] for b in bbox],
+            "y_min": [b[1] for b in bbox],
+            "x_min": [b[2] for b in bbox],
+            "z_max": [b[3] for b in bbox],
+            "y_max": [b[4] for b in bbox],
+            "x_max": [b[5] for b in bbox],
+            "area": area,
+            "minor_axis_length": minor_axis_length,
+            "major_axis_length": major_axis_length,
+            "elongation": elongation,
+        }
+    )
+
+    return spot_quality_metrics(image_3d_aligned, mask_properties)
+
+def spot_quality_metrics(image_3d_aligned, mask_properties):
+    """
+    Compute intensity and quality metrics for each segmented spot.
+
+    Metrics include:
+    - SNR
+    - Mean spot intensity
+    - Spot pixel fraction
+    - Patch skewness
+    - Patch size
+    - Object classification (spot/background)
+
+    Parameters
+    ----------
+    image_3d_aligned : ndarray or str
+        3D image or path to numpy file.
+    mask_properties : Table or DataFrame
+        Spot properties (bbox, centroid).
+
+    Returns
+    -------
+    tuple
+        (spots, snr, spot_fraction, mean_intensity, skewness, patch_size, labels)
+    """
+       
+    mask_properties = mask_properties.to_pandas()
+
+    snr_list = []
+    spot_pixel_percentage = []
+    mean_intensity_list = []
+    object_count_list = []
+    skew_list = []
+    patch_size = []
+    xmin, xmax = [], []
+    ymin, ymax = [], []
+    zmin, zmax = [], []
+    roundness = []
+
+    if len(mask_properties) > 0:
+
+        for idx, row in mask_properties.iterrows():
+
+            # Convert spot coordinates into integer voxel coordinates
+            x_int = int(round(rorow["z_min"]w["x"]))
+            y_int = int(round(row["y"]))
+            z_int = int(round(row["z"]))
+
+            # Extract the local 3D patch using the bounding box coordinates
+            y_min, y_max = round(row["y_min"]), round(row["y_max"])
+            x_min, x_max = round(row["x_min"]), round(row["x_max"])
+            z_min, z_max = round(row["z_min"]), round(row["z_max"])
+
+            xmin.append(x_min)
+            xmax.append(x_max)
+            ymin.append(y_min)
+            ymax.append(y_max)
+            zmin.append(z_min)
+            zmax.append(z_max)
+
+            roundness.append(row["elongation"])
+
+            patch = image_3d_aligned[z_min:z_max, y_min:y_max, x_min:x_max]
+            patch_size.append(round((patch.size)))
+
+            # Segment the patch using Otsu thresholding
+            threshold = threshold_otsu(patch)
+            mask_spot = patch > threshold
+
+            # Compute signal-to-noise (SNR) ratio using the local background
+            background = patch[patch <= threshold]
+
+            if background.size == 0 or np.std(background) == 0:
+                snr_list.append(np.nan)
+            else:
+                I_spot = image_3d_aligned[z_int, y_int, x_int]
+                snr = (I_spot - np.mean(background)) / np.std(background)
+                snr_list.append(snr)
+
+            # Identify connected components inside the segmented patch
+            labeled_mask = label(mask_spot)
+            regions = regionprops(labeled_mask)
+            object_count_list.append(len(regions))
+
+            # Convert global coordinates into local patch coordinates
+            z_local = z_int - z_min
+            y_local = y_int - y_min
+            x_local = x_int - x_min
+
+            label_at_point = labeled_mask[z_local, y_local, x_local]
+
+            if label_at_point == 0:
+                spot_pixel_percentage.append(np.nan)
+                mean_intensity_list.append(np.nan)
+
+            else:
+                region = next(r for r in regions if r.label == label_at_point)
+
+                # Compute spot size and mean intensity
+                spot_pixel_percentage.append(region.area / patch.size * 100)
+
+                mean_intensity_list.append(
+                    round(np.mean(patch[labeled_mask == region.label]))
+                )
+
+            # Compute intensity distribution asymmetry
+            skew_list.append(skew(patch.ravel()), 2)
+
+            # Classify each patch as a spot or background
+        type_object = [
+            1 if not np.isnan(v) else 0
+            for v in spot_pixel_percentage
+        ]
+
+        spots = np.zeros((len(mask_properties), 3), dtype=np.int64)
+
+        spots[:, 0] = mask_properties["z"].round().astype(int)
+        spots[:, 1] = mask_properties["y"].round().astype(int)
+        spots[:, 2] = mask_properties["x"].round().astype(int)
+
+        flux = snr_list
+
+        return (
+            spots,
+            snr_list,
+            spot_pixel_percentage,
+            mean_intensity_list,
+            skew_list,
+            patch_size,
+            type_object,
+            flux,
+            roundness,
+        )
+    
+    else: 
+        return [], [], [], [], [], [], [], [], []
+    
+"""
 def create_output_table():
     output = Table(
         names=(
@@ -720,14 +950,14 @@ def create_output_table():
             "zcentroid",
             "xcentroid",
             "ycentroid",
-            "sharpness",
-            "roundness1",
-            "roundness2",
-            "npix",
-            "sky",
-            "peak",
+            "snr",
+            "spot_pixel_percentage",
+            "skew",
+            "patch_size",
+            "object_class",
+            "mean_intensity",
             "flux",
-            "mag",
+            "roundness",
         ),
         dtype=(
             "S2",
@@ -742,10 +972,11 @@ def create_output_table():
             "f4",
             "f4",
             "int",
-            "f4",
+            "int",
             "f4",
             "f4",
             "f4",
         ),
     )
     return output
+"""

--- a/src/imageProcessing/segmentSources3D.py
+++ b/src/imageProcessing/segmentSources3D.py
@@ -36,7 +36,7 @@ from apifish.identification.spot_modeling import fit_subpixel
 from apifish.image import projection
 from astropy.table import Table, vstack
 from skimage import exposure, io
-from skimage.measure import regionprops
+from skimage.measure import label, regionprops
 from skimage.filters import threshold_otsu
 from scipy.stats import skew
 
@@ -826,7 +826,15 @@ def spot_quality_metrics(image_3d_aligned, mask_properties):
     Returns
     -------
     tuple
-        (spots, snr, spot_fraction, mean_intensity, skewness, patch_size, labels)
+            (spots,
+            snr_list,
+            spot_pixel_percentage,
+            mean_intensity_list,
+            skew_list,
+            patch_size,
+            type_object,
+            flux,
+            roundness)
     """
        
     mask_properties = mask_properties.to_pandas()

--- a/src/imageProcessing/segmentSources3D.py
+++ b/src/imageProcessing/segmentSources3D.py
@@ -34,12 +34,12 @@ from typing import Optional
 import numpy as np
 from apifish.identification.spot_modeling import fit_subpixel
 from apifish.image import projection
-from astropy.table import vstack
-from astropy.table import Table
-from skimage import exposure, io
-from skimage.measure import label, regionprops
-from skimage.filters import threshold_otsu
+from astropy.table import Table, vstack
 from scipy.stats import skew
+from skimage import exposure, io
+from skimage.filters import threshold_otsu
+from skimage.measure import label, regionprops
+from traceratops.core.localization_table import create_output_table
 
 from core.dask_cluster import try_get_client
 from core.parameters import (
@@ -56,12 +56,10 @@ from imageProcessing.alignImages import apply_xy_shift_3d_images
 from imageProcessing.imageProcessing import image_adjust, preprocess_3d_image
 from imageProcessing.makeProjections import reinterpolate_z
 from imageProcessing.segmentMasks import (
+    _deblend_3d_segmentation_advanced,
     _segment_3d_volumes_by_thresholding,
     _segment_3d_volumes_stardist,
-    _deblend_3d_segmentation_advanced,
 )
-
-from traceratops.core.localization_table import create_output_table
 
 # =============================================================================
 # CLASSES
@@ -291,14 +289,16 @@ class Localize3D:
 
         # applies XY or XYZ shift to 3D stack
         if label != p["referenceBarcode"]:
-            
+
             shift_arr = np.asarray(shift)
             if shift_arr.size >= 3:
                 print_log(
                     f"$ Applies shift (z,x,y) = [{shift_arr[0]:.2f}, {shift_arr[1]:.2f}, {shift_arr[2]:.2f}]"
                 )
             else:
-                print_log(f"$ Applies shift (x,y) = [{shift_arr[0]:.2f}, {shift_arr[1]:.2f}]")
+                print_log(
+                    f"$ Applies shift (x,y) = [{shift_arr[0]:.2f}, {shift_arr[1]:.2f}]"
+                )
             image_3d_aligned = apply_xy_shift_3d_images(
                 image_3d, shift, parallel_execution=self.inner_parallel_loop
             )
@@ -363,7 +363,7 @@ class Localize3D:
 
             # calls bigfish to get 3D sub-pixel coordinates based on 3D gaussian fitting
             try:
-                # version 0.4 
+                # version 0.4
                 spots_subpixel = fit_subpixel(
                     image_3d_aligned,
                     spots,
@@ -595,9 +595,9 @@ class Localize3D:
         self.single_file_to_process = single_file_to_process
         output_file_prefix = params.outputFile
         if self.single_file_to_process:
-            base_name = os.path.splitext(
-                os.path.basename(self.single_file_to_process)
-            )[0]
+            base_name = os.path.splitext(os.path.basename(self.single_file_to_process))[
+                0
+            ]
             output_file_prefix = f"{output_file_prefix}_{base_name}"
 
         self.output_filename = (
@@ -735,7 +735,6 @@ def get_mask_properties(
         return [], [], [], [], [], [], [], [], []
 
 
-
 def _safe_region_axis_lengths(region):
     """Return finite 3D region axis lengths, falling back for degenerate objects.
 
@@ -774,6 +773,7 @@ def _safe_region_axis_lengths(region):
 
     return minor_axis, major_axis
 
+
 def get_mask_properties_advanced(segmented_image_3d, image_3d_aligned):
     """
     Extract shape and position features from 3D labeled objects.
@@ -791,20 +791,26 @@ def get_mask_properties_advanced(segmented_image_3d, image_3d_aligned):
         One row per object with centroid, bbox, area, and shape metrics.
     """
 
-    properties = regionprops(segmented_image_3d, intensity_image= image_3d_aligned)
+    properties = regionprops(segmented_image_3d, intensity_image=image_3d_aligned)
 
     if len(properties) == 0:
         return Table(
             names=[
-                "z", "y", "x",
-                "z_min", "y_min", "x_min",
-                "z_max", "y_max", "x_max",
+                "z",
+                "y",
+                "x",
+                "z_min",
+                "y_min",
+                "x_min",
+                "z_max",
+                "y_max",
+                "x_max",
                 "area",
                 "minor_axis_length",
                 "major_axis_length",
                 "elongation",
             ],
-            rows=[]
+            rows=[],
         )
 
     try:
@@ -847,6 +853,7 @@ def get_mask_properties_advanced(segmented_image_3d, image_3d_aligned):
 
     return spot_quality_metrics(image_3d_aligned, mask_properties)
 
+
 def spot_quality_metrics(image_3d_aligned, mask_properties):
     """
     Compute intensity and quality metrics for each segmented spot.
@@ -879,7 +886,7 @@ def spot_quality_metrics(image_3d_aligned, mask_properties):
             flux,
             roundness)
     """
-       
+
     mask_properties = mask_properties.to_pandas()
 
     snr_list = []
@@ -963,10 +970,7 @@ def spot_quality_metrics(image_3d_aligned, mask_properties):
             skew_list.append(skew(patch.ravel()))
 
             # Classify each patch as a spot or background
-        type_object = [
-            1 if not np.isnan(v) else 0
-            for v in spot_pixel_percentage
-        ]
+        type_object = [1 if not np.isnan(v) else 0 for v in spot_pixel_percentage]
 
         spots = np.zeros((len(mask_properties), 3), dtype=np.int64)
 
@@ -987,7 +991,6 @@ def spot_quality_metrics(image_3d_aligned, mask_properties):
             flux,
             roundness,
         )
-    
-    else: 
+
+    else:
         return [], [], [], [], [], [], [], [], []
-    

--- a/src/imageProcessing/segmentSources3D.py
+++ b/src/imageProcessing/segmentSources3D.py
@@ -276,7 +276,7 @@ class Localize3D:
             # uses existing shift calculated by align_images
             try:
                 shift = self.dict_shifts[f"ROI:{roi}"][label]
-                print_log("> Applying existing XY shift...")
+                print_log("> Applying existing shift...")
             except KeyError:
                 shift = None
 

--- a/src/imageProcessing/segmentSources3D.py
+++ b/src/imageProcessing/segmentSources3D.py
@@ -845,7 +845,7 @@ def spot_quality_metrics(image_3d_aligned, mask_properties):
         for idx, row in mask_properties.iterrows():
 
             # Convert spot coordinates into integer voxel coordinates
-            x_int = int(round(rorow["z_min"]w["x"]))
+            x_int = int(round(row["x"]))
             y_int = int(round(row["y"]))
             z_int = int(round(row["z"]))
 

--- a/src/imageProcessing/segmentSources3D.py
+++ b/src/imageProcessing/segmentSources3D.py
@@ -34,7 +34,8 @@ from typing import Optional
 import numpy as np
 from apifish.identification.spot_modeling import fit_subpixel
 from apifish.image import projection
-from astropy.table import Table, vstack
+from astropy.table import vstack
+from astropy.table import Table
 from skimage import exposure, io
 from skimage.measure import label, regionprops
 from skimage.filters import threshold_otsu
@@ -734,8 +735,6 @@ def get_mask_properties(
         return [], [], [], [], [], [], [], [], []
 
 
-
-
 def get_mask_properties_advanced(segmented_image_3d, image_3d_aligned):
     """
     Extract shape and position features from 3D labeled objects.
@@ -948,45 +947,3 @@ def spot_quality_metrics(image_3d_aligned, mask_properties):
     else: 
         return [], [], [], [], [], [], [], [], []
     
-"""
-def create_output_table():
-    output = Table(
-        names=(
-            "Buid",
-            "ROI #",
-            "CellID #",
-            "Barcode #",
-            "id",
-            "zcentroid",
-            "xcentroid",
-            "ycentroid",
-            "snr",
-            "spot_pixel_percentage",
-            "skew",
-            "patch_size",
-            "object_class",
-            "mean_intensity",
-            "flux",
-            "roundness",
-        ),
-        dtype=(
-            "S2",
-            "int",
-            "int",
-            "int",
-            "int",
-            "f4",
-            "f4",
-            "f4",
-            "f4",
-            "f4",
-            "f4",
-            "int",
-            "int",
-            "f4",
-            "f4",
-            "f4",
-        ),
-    )
-    return output
-"""

--- a/src/imageProcessing/segmentSources3D.py
+++ b/src/imageProcessing/segmentSources3D.py
@@ -917,7 +917,7 @@ def spot_quality_metrics(image_3d_aligned, mask_properties):
                 )
 
             # Compute intensity distribution asymmetry
-            skew_list.append(skew(patch.ravel()), 2)
+            skew_list.append(skew(patch.ravel()))
 
             # Classify each patch as a spot or background
         type_object = [

--- a/src/imageProcessing/segmentSources3D.py
+++ b/src/imageProcessing/segmentSources3D.py
@@ -37,6 +37,8 @@ from apifish.image import projection
 from astropy.table import Table, vstack
 from skimage import exposure, io
 from skimage.measure import regionprops
+from skimage.filters import threshold_otsu
+from scipy.stats import skew
 
 from core.dask_cluster import try_get_client
 from core.parameters import (

--- a/src/imageProcessing/segmentSources3D.py
+++ b/src/imageProcessing/segmentSources3D.py
@@ -735,6 +735,45 @@ def get_mask_properties(
         return [], [], [], [], [], [], [], [], []
 
 
+
+def _safe_region_axis_lengths(region):
+    """Return finite 3D region axis lengths, falling back for degenerate objects.
+
+    scikit-image derives axis lengths from inertia-tensor eigenvalues. Very
+    small, flat, or numerically degenerate 3D labels can produce a slightly
+    negative value inside the square-root used for ``axis_minor_length`` or
+    ``axis_major_length``, which raises ``ValueError: math domain error``.
+    Treat those labels as valid detections but mark their unavailable axis
+    length as 0 so downstream roundness/elongation metrics remain safe.
+    """
+
+    try:
+        minor_axis = region.minor_axis_length
+    except ValueError:
+        print_log(
+            f"$ Warning: could not compute minor axis length for label "
+            f"{region.label}; using 0. This usually indicates a degenerate "
+            "or very small 3D object."
+        )
+        minor_axis = 0
+
+    try:
+        major_axis = region.major_axis_length
+    except ValueError:
+        print_log(
+            f"$ Warning: could not compute major axis length for label "
+            f"{region.label}; using 0. This usually indicates a degenerate "
+            "or very small 3D object."
+        )
+        major_axis = 0
+
+    if not np.isfinite(minor_axis) or minor_axis < 0:
+        minor_axis = 0
+    if not np.isfinite(major_axis) or major_axis < 0:
+        major_axis = 0
+
+    return minor_axis, major_axis
+
 def get_mask_properties_advanced(segmented_image_3d, image_3d_aligned):
     """
     Extract shape and position features from 3D labeled objects.
@@ -775,8 +814,13 @@ def get_mask_properties_advanced(segmented_image_3d, image_3d_aligned):
 
     bbox = [p.bbox for p in properties]
     area = [p.area for p in properties]
-    minor_axis_length = [p.minor_axis_length for p in properties]
-    major_axis_length = [p.major_axis_length for p in properties]
+    minor_axis_length = []
+    major_axis_length = []
+
+    for prop in properties:
+        minor_axis, major_axis = _safe_region_axis_lengths(prop)
+        minor_axis_length.append(minor_axis)
+        major_axis_length.append(major_axis)
 
     elongation = [
         major_axis_length[i] / minor_axis_length[i] if minor_axis_length[i] > 0 else 0

--- a/src/matrixOperations/build_traces.py
+++ b/src/matrixOperations/build_traces.py
@@ -747,9 +747,16 @@ class BuildTraces:
         matrix_params: MatrixParams,
         acq_params: AcquisitionParams,
     ):
-        # loads barcode coordinate Tables
+        # loads barcode coordinate table and plots statistics
         table = LocalizationTable()
         barcode_map, self.unique_barcodes = table.load(file)
+
+        filepath_split = file.split(".")[0].split(os.sep).remove("data")
+        filepath_without_data_folder = (os.sep).join(filepath_split)
+        table.plot_distribution_fluxes(barcode_map, 
+                                       [filepath_without_data_folder, "_stats", ".png"]
+                                        )        
+        
         print_log(f"$ {len(barcode_map)} localizations in {os.path.basename(file)}")
         if "3D" in os.path.basename(file):
             self.ndims = 3
@@ -769,7 +776,7 @@ class BuildTraces:
 
         if (
             "clustering" in matrix_params.tracing_method and self.ndims == 3
-        ):  # for now it only runs for 3D data
+        ):  
             self.build_trace_by_clustering(barcode_map, data_path, matrix_params)
         elif self.ndims == 2:
             print_log(

--- a/src/matrixOperations/build_traces.py
+++ b/src/matrixOperations/build_traces.py
@@ -751,12 +751,14 @@ class BuildTraces:
         table = LocalizationTable()
         barcode_map, self.unique_barcodes = table.load(file)
 
-        filepath_split = file.split(".")[0].split(os.sep).remove("data")
+        filepath_split = file.split(".")[0].split(os.sep)  # remove ext + split path
+        filepath_split.remove("data")
         filepath_without_data_folder = (os.sep).join(filepath_split)
-        table.plot_distribution_fluxes(barcode_map, 
-                                       [filepath_without_data_folder, "_stats", ".png"]
-                                        )        
-        
+
+        table.plot_distribution_fluxes(
+            barcode_map, [filepath_without_data_folder, "_stats", ".png"]
+        )
+
         print_log(f"$ {len(barcode_map)} localizations in {os.path.basename(file)}")
         if "3D" in os.path.basename(file):
             self.ndims = 3
@@ -774,9 +776,7 @@ class BuildTraces:
                 barcode_map, data_path, seg_params, matrix_params, acq_params
             )
 
-        if (
-            "clustering" in matrix_params.tracing_method and self.ndims == 3
-        ):  
+        if "clustering" in matrix_params.tracing_method and self.ndims == 3:
             self.build_trace_by_clustering(barcode_map, data_path, matrix_params)
         elif self.ndims == 2:
             print_log(
@@ -848,8 +848,10 @@ def debug_mask_filename(
                 ROI: {int(os.path.basename(file).split("_")[3])}'
         )
 
+
 def binarize_coordinate(x):
     return np.nan if np.isnan(x) else int(x)
+
 
 def project_spot_coord_in_mask_ref(
     x, y, z, pixel_size_xy, pixel_size_z, mask_pixel_size_xy, mask_pixel_size_z

--- a/src/matrixOperations/filter_localizations.py
+++ b/src/matrixOperations/filter_localizations.py
@@ -155,8 +155,8 @@ class FilterLocalizations:
             + os.sep
             + seg_params.outputFile
         )
-#        files = list(glob.glob(data_file_base_2d + "_*barcode.dat"))
-#        files += list(glob.glob(data_file_base_3d + "_*barcode.dat"))
+        #        files = list(glob.glob(data_file_base_2d + "_*barcode.dat"))
+        #        files += list(glob.glob(data_file_base_3d + "_*barcode.dat"))
         files = list(glob.glob(data_file_base_2d + "_2D_barcode.dat"))
         files += list(glob.glob(data_file_base_3d + "_3D_barcode.dat"))
         if files:

--- a/src/matrixOperations/merge_inputs.py
+++ b/src/matrixOperations/merge_inputs.py
@@ -63,10 +63,8 @@ class MergeInputs:
             format="ascii.ecsv",
             overwrite=True,
         )
-                
-        print_log(
-            f"$ Merged {len(tables)} {description} table(s) into: {output_path}"
-        )
+
+        print_log(f"$ Merged {len(tables)} {description} table(s) into: {output_path}")
         return True
 
     def merge_localization_tables(
@@ -124,7 +122,10 @@ class MergeInputs:
         return output_path if merged else None
 
     def merge_all(
-        self, data_path: str, seg_params: SegmentationParams, reg_params: RegistrationParams
+        self,
+        data_path: str,
+        seg_params: SegmentationParams,
+        reg_params: RegistrationParams,
     ) -> Optional[str]:
         """Merge both localization and registration tables.
 

--- a/src/matrixOperations/register_localizations.py
+++ b/src/matrixOperations/register_localizations.py
@@ -404,7 +404,6 @@ class RegisterLocalizations:
             f"## {session_name}\n",
             "a",
         )
-        label = "barcode"
 
         current_folder = data_path
         print_log(f"> Processing Folder: {current_folder}")
@@ -438,11 +437,11 @@ class RegisterLocalizations:
             + os.sep
             + seg_params.outputFile
         )
-#        files = list(glob.glob(data_file_base_2d + "_*" + label + ".dat"))
-#        files += list(glob.glob(data_file_base_3d + "_*" + label + ".dat"))
+        #        files = list(glob.glob(data_file_base_2d + "_*" + label + ".dat"))
+        #        files += list(glob.glob(data_file_base_3d + "_*" + label + ".dat"))
         files = list(glob.glob(data_file_base_2d + "_2D_barcode.dat"))
         files += list(glob.glob(data_file_base_3d + "_3D_barcode.dat"))
-        
+
         if not files:
             print_log("No localization table found to process!")
             return

--- a/src/postProcessing/mask_manual.py
+++ b/src/postProcessing/mask_manual.py
@@ -90,7 +90,7 @@ def shift_3d_mask(mask_3d_path):
     # uses existing shift calculated by align_images
     try:
         shift = dict_shifts[f"ROI:{roi_name}"][label]
-        print("> Applying existing XY shift...")
+        print("> Applying existing shift...")
     except KeyError as e:
         shift = None
         raise SystemExit(

--- a/src/toolbox/file_handling/zipHiM_run.py
+++ b/src/toolbox/file_handling/zipHiM_run.py
@@ -55,7 +55,10 @@ def main():
         files = []
         for directory in search_dirs:
             files.extend(
-                [os.path.relpath(f, root_folder) for f in glob.glob(directory + os.sep + pattern)]
+                [
+                    os.path.relpath(f, root_folder)
+                    for f in glob.glob(directory + os.sep + pattern)
+                ]
             )
         return files
 

--- a/tests/test_merge_inputs.py
+++ b/tests/test_merge_inputs.py
@@ -1,12 +1,11 @@
-import pytest
-
-pytest.importorskip("astropy")
-
 from types import SimpleNamespace
 
+import pytest
 from astropy.table import Table
 
 from matrixOperations.merge_inputs import MergeInputs
+
+pytest.importorskip("astropy")
 
 
 def _write_dummy_table(path, value):
@@ -43,7 +42,10 @@ def test_merge_inputs_creates_expected_outputs(tmp_path):
     merged_local_shifts = merger.merge_all(data_path, seg_params, reg_params)
 
     merged_localizations = (
-        data_path / seg_params.localize_3d_folder / "data" / "localizations_3D_barcode.dat"
+        data_path
+        / seg_params.localize_3d_folder
+        / "data"
+        / "localizations_3D_barcode.dat"
     )
     merged_registration = (
         data_path / reg_params.register_local_folder / "data" / "shifts_block3D.dat"
@@ -71,7 +73,10 @@ def test_merge_inputs_skips_when_outputs_present(tmp_path):
     )
 
     existing_localization = (
-        data_path / seg_params.localize_3d_folder / "data" / "localizations_3D_barcode.dat"
+        data_path
+        / seg_params.localize_3d_folder
+        / "data"
+        / "localizations_3D_barcode.dat"
     )
     existing_localization.parent.mkdir(parents=True, exist_ok=True)
     _write_dummy_table(existing_localization, 10)


### PR DESCRIPTION
localize_3d:

- improved deblending using watershed which in some cases led to masks not being split or masks being wrongly split in two if the maxima were too close.
- now calculate several descriptors for each spot (snr, skew, roundness, etc) which are reported in the localization table
- localization table changed adding these descriptors and removing previous columns: peak, flux, mag, etc. See traceratops for more description.
- added instructions to install pyiM using uv
- filter_localizations now deprecated.
- analysis of localization table is now performed in `build_traces`