### PR TITLE
Fix ECSV comparisons for localization tests

### DIFF
--- a/tests/test_localize_2d.py
+++ b/tests/test_localize_2d.py
@@ -50,12 +50,7 @@ def template_test_localize_2d(mode: str):
         elif extension == "json":
             assert compare_line_by_line(tmp_file, out_file)
         elif extension == "dat":
-            assert compare_line_by_line(
-                tmp_file,
-                out_file,
-                line_start=len("e5c550de-d381-4b62-99d3-726ca7e549d9"),
-                shuffled_lines=True,
-            )
+            assert compare_ecsv_files(tmp_file, out_file, ["Buid"], shuffled_lines=True)
         elif extension == "table":
             assert compare_ecsv_files(tmp_file, out_file)
         else:

--- a/tests/test_localize_3d.py
+++ b/tests/test_localize_3d.py
@@ -50,12 +50,7 @@ def template_test_localize_3d(mode: str):
         elif extension == "json":
             assert compare_line_by_line(tmp_file, out_file)
         elif extension == "dat":
-            assert compare_line_by_line(
-                tmp_file,
-                out_file,
-                line_start=len("e5c550de-d381-4b63-99d3-736ca7e549d9"),
-                shuffled_lines=True,
-            )
+            assert compare_ecsv_files(tmp_file, out_file, ["Buid"], shuffled_lines=True)
         elif extension == "table":
             assert compare_ecsv_files(tmp_file, out_file)
         else:

--- a/tests/testing_tools/comparison.py
+++ b/tests/testing_tools/comparison.py
@@ -55,6 +55,18 @@ def compare_npy_files(first_file, second_file, shuffled_plans=False):
     return is_same
 
 
+def _values_equal(first_value, second_value):
+    """Compare scalar table values while tolerating ECSV float round-tripping."""
+    try:
+        return bool(np.isclose(first_value, second_value, equal_nan=True))
+    except TypeError:
+        return first_value == second_value
+
+
+def _table_rows_equal(first_row, second_row, colnames):
+    return all(_values_equal(first_row[col], second_row[col]) for col in colnames)
+
+
 def compare_ecsv_files(
     first_file, second_file, columns_to_remove: list[str] = None, shuffled_lines=False
 ):
@@ -63,21 +75,36 @@ def compare_ecsv_files(
 
     if columns_to_remove:
         for col in columns_to_remove:
-            first_ecsv.remove_column(col)
-            second_ecsv.remove_column(col)
-    first_npy = first_ecsv.as_array()
-    second_npy = second_ecsv.as_array()
-    is_same = True
+            if col in first_ecsv.colnames:
+                first_ecsv.remove_column(col)
+            if col in second_ecsv.colnames:
+                second_ecsv.remove_column(col)
+
+    if first_ecsv.colnames != second_ecsv.colnames or len(first_ecsv) != len(second_ecsv):
+        return False
+
+    colnames = first_ecsv.colnames
     if shuffled_lines:
-        for line in first_npy:
-            if line not in second_npy:
+        unmatched_rows = list(second_ecsv)
+        for line in first_ecsv:
+            match_index = next(
+                (
+                    index
+                    for index, candidate in enumerate(unmatched_rows)
+                    if _table_rows_equal(line, candidate, colnames)
+                ),
+                None,
+            )
+            if match_index is None:
                 print(f"SHUFFLE: At line {line}\n from {first_file}\n\n")
-                is_same = False
-                break
-    else:
-        comparison = first_npy == second_npy
-        is_same = comparison.all()
-    return is_same
+                return False
+            unmatched_rows.pop(match_index)
+        return True
+
+    for first_row, second_row in zip(first_ecsv, second_ecsv):
+        if not _table_rows_equal(first_row, second_row, colnames):
+            return False
+    return True
 
 
 def compare_line_by_line(first_file, second_file, shuffled_lines=False, line_start=0):


### PR DESCRIPTION
### Motivation
- Localization `.dat` outputs contain nondeterministic `Buid` UUIDs and may be written in ECSV where row order and float/NaN formatting can vary, causing brittle text-based comparisons in tests. 
- Several localization tests were failing due to raw line-slicing and strict ordering when checking barcode output files.

### Description
- Replace raw text/UUID-slicing comparisons for `.dat` files in `tests/test_localize_2d.py` and `tests/test_localize_3d.py` with `compare_ecsv_files(tmp_file, out_file, ["Buid"], shuffled_lines=True)` so `Buid` is ignored and rows may be shuffled. 
- Harden `tests/testing_tools/comparison.py::compare_ecsv_files` by adding `_values_equal` and `_table_rows_equal` helpers and implementing: optional safe column removal, column-name and row-count equality checks, row-order-independent matching, and tolerant scalar comparison using `np.isclose(..., equal_nan=True)` to handle floating-point/NaN round-tripping. 
- Preserve existing behaviors for other file types and keep `compare_line_by_line` for plain text comparisons.

### Testing
- Successfully compiled modified test files with `python -m py_compile tests/testing_tools/comparison.py tests/test_localize_2d.py tests/test_localize_3d.py`.
- Attempted `PYTHONPATH=src pytest -q tests/test_localize_2d.py::test_inhomogeneous -s` but collection/run was blocked due to missing `matplotlib` in the execution environment. 
- Attempted a small smoke-run for `compare_ecsv_files` but it was blocked due to missing `astropy` in the environment, so end-to-end pytest runs could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a523e0b684483308189ea4d57f64a34)