### PR TITLE
Use ECSV for localization and registration tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project since the last release will be documented in
 ### Changed
 
 * Localization and registration table outputs now standardize on `.ecsv` filenames for compatibility with downstream traceratops processing.
-* `filter_localizations`, `register_localizations`, `build_traces`, and input-merging helpers now look for `.ecsv` localization tables.
+* `filter_localizations`, `register_localizations`, `build_traces`, data discovery, and input-merging helpers now look for `.ecsv` localization and local-registration tables.
 * Documentation and tests now reference `.ecsv` localization and registration table filenames.
 
 ## [Template] - YYYY-MM-DD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## [unrelease]
+
+All notable changes to this project since the last release will be documented in this section.
+
+### Changed
+
+* Localization and registration table outputs now standardize on `.ecsv` filenames for compatibility with downstream traceratops processing.
+* `filter_localizations`, `register_localizations`, `build_traces`, and input-merging helpers now look for `.ecsv` localization tables.
+* Documentation and tests now reference `.ecsv` localization and registration table filenames.
+
+## [Template] - YYYY-MM-DD
+
+### Added
+
+### Fixed
+
+### Changed
+
+### Removed

--- a/docs/source/getting_started/tutorials/notebooks/jupyter_functions_plots.py
+++ b/docs/source/getting_started/tutorials/notebooks/jupyter_functions_plots.py
@@ -16,13 +16,13 @@ from matplotlib import rcParams
 
 
 def copy_localization_table(input_folder):
-    source = os.path.join(input_folder, "localizations_3D_barcode_example.dat")
+    source = os.path.join(input_folder, "localizations_3D_barcode_example.ecsv")
     dest = os.path.join(
         input_folder,
         "analysis_localizations",
         "localize_3d",
         "data",
-        "localizations_3D_barcode.dat",
+        "localizations_3D_barcode.ecsv",
     )
     folder_path = os.path.join(
         input_folder, "analysis_localizations", "localize_3d", "data"

--- a/docs/source/user_guide/modules/preprocessing/align_images.md
+++ b/docs/source/user_guide/modules/preprocessing/align_images.md
@@ -17,7 +17,7 @@ pyhim -C register_global
 ## Outputs
 |Name shape|Quantity|Description|
 |---|---|---|
-|shifts.table|1|Text table containing the global shift dictionary for each image (X,Y in `2D` mode; Z,X,Y in `3D` mode).|
+|shifts.ecsv|1|Text table containing the global shift dictionary for each image (X,Y in `2D` mode; Z,X,Y in `3D` mode).|
 |shifts.json|1|JSON file containing the global shift dictionary for each image (X,Y in `2D` mode; Z,X,Y in `3D` mode).|
 
 ## Relevant options

--- a/src/core/data_file.py
+++ b/src/core/data_file.py
@@ -110,7 +110,7 @@ class JsonFile(DataFile):
 class EcsvFile(DataFile):
     def __init__(self, data):
         super().__init__(data)
-        self.extension = "table"
+        self.extension = "ecsv"
         self.folder_path = ""
         self.basename = ""
         self.path_name = ""

--- a/src/core/data_manager.py
+++ b/src/core/data_manager.py
@@ -256,7 +256,7 @@ class DataManager:
                 name_to_find = (
                     str(register_out_file) + "_" + str(register_local_alignment)
                 )
-                if ext == "dat" and name == name_to_find:
+                if ext in ("ecsv", "dat") and name == name_to_find:
                     self.local_shifts_path = path
                 elif "barcode" in name:
                     self.add_to_processable_labels("barcode")

--- a/src/imageProcessing/alignImages3D.py
+++ b/src/imageProcessing/alignImages3D.py
@@ -296,7 +296,7 @@ class Drift3D:
             + os.sep
             + output_prefix
         )
-        local_shifts_path = path_name + "_block3D.dat"
+        local_shifts_path = path_name + "_block3D.ecsv"
 
         alignment_results_table_global.write(
             local_shifts_path,

--- a/src/imageProcessing/segmentMasks.py
+++ b/src/imageProcessing/segmentMasks.py
@@ -786,7 +786,7 @@ def segment_masks(
         + params.outputFile
         + "_"
         + label
-        + ".dat"
+        + ".ecsv"
     )
     if current_param.param_dict["parallel"]:
         # running in parallel mode

--- a/src/imageProcessing/segmentSources3D.py
+++ b/src/imageProcessing/segmentSources3D.py
@@ -608,7 +608,7 @@ class Localize3D:
             + "data"
             + os.sep
             + output_file_prefix
-            + "_3D_barcode.dat"
+            + "_3D_barcode.ecsv"
         )
 
         print_log(f"> Processing Folder: {data_path}")

--- a/src/matrixOperations/build_traces.py
+++ b/src/matrixOperations/build_traces.py
@@ -587,7 +587,7 @@ class BuildTraces:
     def group_localizations_by_coordinate(self, matrix_params: MatrixParams):
         """
         Uses a KDTree to group detections by it's coordinates, given a certain distance threshold
-        Returns a list of lists. Each list contains the lines if the input data (segmentedObjects_3D_barcode.dat)
+        Returns a list of lists. Each list contains the lines if the input data (segmentedObjects_3D_barcode.ecsv)
         where the detections are less than a pixel away from each other
 
         Parameters
@@ -807,8 +807,8 @@ class BuildTraces:
         # iterates over consolidated barcode localization tables in the current folder
         files = []
         for folder, suffix in (
-            (seg_params.localize_2d_folder, "_2D_barcode.dat"),
-            (seg_params.localize_3d_folder, "_3D_barcode.dat"),
+            (seg_params.localize_2d_folder, "_2D_barcode.ecsv"),
+            (seg_params.localize_3d_folder, "_3D_barcode.ecsv"),
         ):
             consolidated_path = os.path.join(
                 data_path, folder, "data", f"{seg_params.outputFile}{suffix}"

--- a/src/matrixOperations/filter_localizations.py
+++ b/src/matrixOperations/filter_localizations.py
@@ -155,10 +155,10 @@ class FilterLocalizations:
             + os.sep
             + seg_params.outputFile
         )
-        #        files = list(glob.glob(data_file_base_2d + "_*barcode.dat"))
-        #        files += list(glob.glob(data_file_base_3d + "_*barcode.dat"))
-        files = list(glob.glob(data_file_base_2d + "_2D_barcode.dat"))
-        files += list(glob.glob(data_file_base_3d + "_3D_barcode.dat"))
+        #        files = list(glob.glob(data_file_base_2d + "_*barcode.ecsv"))
+        #        files += list(glob.glob(data_file_base_3d + "_*barcode.ecsv"))
+        files = list(glob.glob(data_file_base_2d + "_2D_barcode.ecsv"))
+        files += list(glob.glob(data_file_base_3d + "_3D_barcode.ecsv"))
         if files:
             for file in files:
                 self.ndims = 3 if "3D" in os.path.basename(file) else 2
@@ -218,7 +218,7 @@ class FilterLocalizations:
 
 
 def get_file_table_new_name(file):
-    existing_versions = glob.glob(file.split(".")[0] + "_version_*.dat")
+    existing_versions = glob.glob(os.path.splitext(file)[0] + "_version_*.ecsv")
 
     if len(existing_versions) < 1:
         new_version = 0
@@ -228,4 +228,4 @@ def get_file_table_new_name(file):
         ]
 
         new_version = max(version_numbers) + 1 if version_numbers else 0
-    return file.split(".dat")[0] + "_version_" + str(new_version) + ".dat"
+    return os.path.splitext(file)[0] + "_version_" + str(new_version) + ".ecsv"

--- a/src/matrixOperations/merge_inputs.py
+++ b/src/matrixOperations/merge_inputs.py
@@ -73,8 +73,8 @@ class MergeInputs:
         """Merge per-file localization tables into the expected filenames."""
 
         for folder, suffix in (
-            (seg_params.localize_2d_folder, "_2D_barcode.dat"),
-            (seg_params.localize_3d_folder, "_3D_barcode.dat"),
+            (seg_params.localize_2d_folder, "_2D_barcode.ecsv"),
+            (seg_params.localize_3d_folder, "_3D_barcode.ecsv"),
         ):
             output_path = os.path.join(
                 data_path, folder, "data", f"{seg_params.outputFile}{suffix}"
@@ -103,7 +103,7 @@ class MergeInputs:
             data_path,
             reg_params.register_local_folder,
             "data",
-            f"{reg_params.outputFile}_block3D.dat",
+            f"{reg_params.outputFile}_block3D.ecsv",
         )
         if os.path.exists(output_path):
             print_log(
@@ -115,7 +115,7 @@ class MergeInputs:
             data_path,
             reg_params.register_local_folder,
             "data",
-            f"{reg_params.outputFile}_*_block3D.dat",
+            f"{reg_params.outputFile}_*_block3D.ecsv",
         )
         files = sorted(glob.glob(pattern))
         merged = self._merge_tables(files, output_path, "registration")

--- a/src/matrixOperations/register_localizations.py
+++ b/src/matrixOperations/register_localizations.py
@@ -437,10 +437,10 @@ class RegisterLocalizations:
             + os.sep
             + seg_params.outputFile
         )
-        #        files = list(glob.glob(data_file_base_2d + "_*" + label + ".dat"))
-        #        files += list(glob.glob(data_file_base_3d + "_*" + label + ".dat"))
-        files = list(glob.glob(data_file_base_2d + "_2D_barcode.dat"))
-        files += list(glob.glob(data_file_base_3d + "_3D_barcode.dat"))
+        #        files = list(glob.glob(data_file_base_2d + "_*" + label + ".ecsv"))
+        #        files += list(glob.glob(data_file_base_3d + "_*" + label + ".ecsv"))
+        files = list(glob.glob(data_file_base_2d + "_2D_barcode.ecsv"))
+        files += list(glob.glob(data_file_base_3d + "_3D_barcode.ecsv"))
 
         if not files:
             print_log("No localization table found to process!")

--- a/tests/testData.json
+++ b/tests/testData.json
@@ -27,7 +27,7 @@
     },
     "test_segmentsMasks": {
         "expectedOutputs": [
-            "/home/marcnol/data/Embryo_debug_dataset/Experiment_18/segmentedObjects/segmentedObjects_barcode.dat",
+            "/home/marcnol/data/Embryo_debug_dataset/Experiment_18/segmentedObjects/segmentedObjects_barcode.ecsv",
             "/home/marcnol/data/Embryo_debug_dataset/Experiment_18/segmentedObjects/scan_006_DAPI_001_ROI_converted_decon_ch00_Masks.npy"
         ],
         "fileName2Process": [

--- a/tests/test_merge_inputs.py
+++ b/tests/test_merge_inputs.py
@@ -1,11 +1,11 @@
 from types import SimpleNamespace
 
 import pytest
-
-pytest.importorskip("astropy")
 from astropy.table import Table
 
 from matrixOperations.merge_inputs import MergeInputs
+
+pytest.importorskip("astropy")
 
 
 def _write_dummy_table(path, value):

--- a/tests/test_merge_inputs.py
+++ b/tests/test_merge_inputs.py
@@ -1,11 +1,11 @@
 from types import SimpleNamespace
 
 import pytest
+
+pytest.importorskip("astropy")
 from astropy.table import Table
 
 from matrixOperations.merge_inputs import MergeInputs
-
-pytest.importorskip("astropy")
 
 
 def _write_dummy_table(path, value):
@@ -25,8 +25,8 @@ def test_merge_inputs_creates_expected_outputs(tmp_path):
     )
 
     for folder, suffix, values in (
-        (seg_params.localize_3d_folder, "_3D_barcode.dat", [1, 2]),
-        (reg_params.register_local_folder, "_block3D.dat", [3, 4]),
+        (seg_params.localize_3d_folder, "_3D_barcode.ecsv", [1, 2]),
+        (reg_params.register_local_folder, "_block3D.ecsv", [3, 4]),
     ):
         for idx, val in enumerate(values):
             file_path = (
@@ -45,10 +45,10 @@ def test_merge_inputs_creates_expected_outputs(tmp_path):
         data_path
         / seg_params.localize_3d_folder
         / "data"
-        / "localizations_3D_barcode.dat"
+        / "localizations_3D_barcode.ecsv"
     )
     merged_registration = (
-        data_path / reg_params.register_local_folder / "data" / "shifts_block3D.dat"
+        data_path / reg_params.register_local_folder / "data" / "shifts_block3D.ecsv"
     )
 
     assert merged_localizations.exists()
@@ -76,13 +76,13 @@ def test_merge_inputs_skips_when_outputs_present(tmp_path):
         data_path
         / seg_params.localize_3d_folder
         / "data"
-        / "localizations_3D_barcode.dat"
+        / "localizations_3D_barcode.ecsv"
     )
     existing_localization.parent.mkdir(parents=True, exist_ok=True)
     _write_dummy_table(existing_localization, 10)
 
     existing_registration = (
-        data_path / reg_params.register_local_folder / "data" / "shifts_block3D.dat"
+        data_path / reg_params.register_local_folder / "data" / "shifts_block3D.ecsv"
     )
     existing_registration.parent.mkdir(parents=True, exist_ok=True)
     _write_dummy_table(existing_registration, 20)

--- a/tests/test_register_local.py
+++ b/tests/test_register_local.py
@@ -49,7 +49,7 @@ def template_test_register_local(mode: str):
             assert image_pixel_differences(tmp_file, out_file)
         elif extension == "json":
             assert compare_line_by_line(tmp_file, out_file)
-        elif extension == "table" or extension == "dat":
+        elif extension in ["ecsv", "table", "dat"]:
             assert compare_ecsv_files(tmp_file, out_file, shuffled_lines=True)
         else:
             raise ValueError(f"Extension file UNRECOGNIZED: {filepath}")


### PR DESCRIPTION
### Motivation
- Downstream tools (e.g. `traceratops`) standardize on ECSV, so localization and registration tables should use `.ecsv` to avoid format mismatches across the pipeline.
- Ensure all modules that produce or consume localization/registration outputs look for the new extension so the processing chain remains consistent.

### Description
- Change the table saver to use the `ecsv` extension by setting `EcsvFile.extension = "ecsv"` while still writing with Astropy `format="ascii.ecsv"` (`src/core/data_file.py`).
- Update producers to write `.ecsv` names for localization and registration outputs (e.g. `localizations_*_barcode.ecsv` and `_block3D.ecsv`) in `segmentSources3D`, `segmentMasks`, and `alignImages3D`.
- Update downstream consumers to search for `.ecsv` files and versioned backups to use `_version_*.ecsv` in `filter_localizations`, `register_localizations`, `build_traces`, and `merge_inputs`.
- Adjust tests and documentation references to the new `.ecsv` filenames and update the merge test to import-skip Astropy if unavailable (`tests/test_merge_inputs.py`, `tests/testData.json`, docs notebook and user guide entries).

### Testing
- Compiled the modified modules with `python -m py_compile` for the changed files and the compilation completed without syntax errors.
- Ran `pytest -q tests/test_merge_inputs.py`, which was executed but skipped due to the test environment lacking the `astropy` dependency (tests adapted to use `ascii.ecsv` and now skip cleanly when `astropy` is not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a58873dc7508330af59eb34d1f2fc3f)